### PR TITLE
Avoid error in integration for shot instance

### DIFF
--- a/client/ayon_resolve/plugins/publish/precollect_instances.py
+++ b/client/ayon_resolve/plugins/publish/precollect_instances.py
@@ -172,7 +172,13 @@ class PrecollectInstances(pyblish.api.ContextPlugin):
             "productType": product_type,
             "family": product_type,
             "families": [product_type],
-            "publish": get_publish_attribute(timeline_item)
+            "publish": get_publish_attribute(timeline_item),
+
+            # Tell the integrator this instance does not publish products
+            # with versions and representation. This product is solely
+            # intended to created shot hierarchies via the 'Extract Hierarchy
+            # to AYON' plug-in in ayon-core.
+            "integrate": False
         })
 
         context.create_instance(**data)


### PR DESCRIPTION
Add `integrate = False` data to the shot instance so the integrator doesn't error on it having no representations.

This fixes #5