### PR TITLE
Resolve: enhancing editorial pkg loader

### DIFF
--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -1,7 +1,8 @@
 import sys
-import json
 import re
 import os
+import json
+import uuid
 import contextlib
 from typing import List, Dict, Any
 from opentimelineio import opentime
@@ -38,6 +39,27 @@ self.temp_marker_frame = None
 
 # OpenPype default timeline
 self.pype_timeline_name = "OpenPypeTimeline"
+
+
+def get_timeline_media_pool_item(timeline, root=None):
+    """Return MediaPoolItem from Timeline"""
+
+    # Due to limitations in the Resolve API we can't get
+    # the media pool item directly from the timeline.
+    # We can find it by name, however names are not
+    # enforced to be unique across bins. So, we give it
+    # unique name.
+    original_name = timeline.GetName()
+    identifier = str(uuid.uuid4().hex)
+    try:
+        timeline.SetName(identifier)
+        for item in iter_all_media_pool_clips(root=root):
+            if item.GetName() != identifier:
+                continue
+            return item
+    finally:
+        # Revert to original name
+        timeline.SetName(original_name)
 
 
 @contextlib.contextmanager

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -961,7 +961,8 @@ def iter_all_media_pool_clips(root=None):
     """Recursively iterate all media pool clips in current project
 
     Args:
-        root (resolve.Folder)[optional]: root folder / bin object
+        root (Optional[resolve.Folder]): root folder / bin object.
+            When None, defaults to media pool root folder.
     """
     root = root or get_current_project().GetMediaPool().GetRootFolder()
     queue = [root]

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -960,9 +960,13 @@ def get_reformated_path(path, padded=False, first=False):
     return path
 
 
-def iter_all_media_pool_clips():
-    """Recursively iterate all media pool clips in current project"""
-    root = get_current_project().GetMediaPool().GetRootFolder()
+def iter_all_media_pool_clips(root=None):
+    """Recursively iterate all media pool clips in current project
+
+    Args:
+        root (resolve.Folder)[optional]: root folder / bin object
+    """
+    root = root or get_current_project().GetMediaPool().GetRootFolder()
     queue = [root]
     for folder in queue:
         for clip in folder.GetClipList():

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -41,8 +41,17 @@ self.temp_marker_frame = None
 self.pype_timeline_name = "OpenPypeTimeline"
 
 
-def get_timeline_media_pool_item(timeline, root=None):
-    """Return MediaPoolItem from Timeline"""
+def get_timeline_media_pool_item(timeline, root=None) -> object:
+    """Return MediaPoolItem from Timeline
+
+
+    Args:
+        timeline (resolve.Timeline): timeline object
+        root (resolve.Folder): root folder / bin object
+
+    Returns:
+        resolve.MediaPoolItem: media pool item from timeline
+    """
 
     # Due to limitations in the Resolve API we can't get
     # the media pool item directly from the timeline.

--- a/client/ayon_resolve/api/pipeline.py
+++ b/client/ayon_resolve/api/pipeline.py
@@ -157,6 +157,9 @@ def ls():
         data = json.loads(data)
 
         # treat data as container
+        # There might be cases where clip's metadata are having additional
+        # because it needs to store 'load' and 'publish' data. In that case
+        # we need to get only 'load' data
         if data.get("load"):
             data = data["load"]
 

--- a/client/ayon_resolve/api/pipeline.py
+++ b/client/ayon_resolve/api/pipeline.py
@@ -156,6 +156,10 @@ def ls():
             continue
         data = json.loads(data)
 
+        # treat data as container
+        if data.get("load"):
+            data = data["load"]
+
         # If not all required data, skip it
         required = ['schema', 'id', 'loader', 'representation']
         if not all(key in data for key in required):

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -5,6 +5,7 @@ import copy
 import qargparse
 from qtpy import QtWidgets, QtCore
 
+from ayon_core.pipeline.constants import AVALON_INSTANCE_ID
 from ayon_core.settings import get_current_project_settings
 from ayon_core.pipeline import (
     LegacyCreator,
@@ -899,6 +900,35 @@ class PublishClip:
         for key in par_split:
             parent = self._convert_to_entity(key)
             self.parents.append(parent)
+
+
+def get_editorial_publish_data(
+    folder_path,
+    product_name,
+    version=None
+) -> dict:
+    """Get editorial publish data from context.
+
+    Args:
+        folder_path (str): Folder path where editorial package is located.
+        product_name (str): Editorial product name.
+        version (Optional[str]): Editorial product version. Defaults to None.
+
+    Returns:
+        dict: Editorial publish data.
+    """
+    data = {
+        "id": AVALON_INSTANCE_ID,
+        "productType": "editorial_pkg",
+        "productName": product_name,
+        "folderPath": folder_path,
+        "active": True,
+    }
+
+    if version:
+        data["version"] = version
+
+    return data
 
 
 def get_representation_files(representation):

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -16,22 +16,13 @@ class CreateEditorialPackage(LegacyCreator):
     def process(self):
         """Process the creation of the editorial package."""
         current_timeline = lib.get_current_timeline()
-        timeline_name = current_timeline.GetName()
 
-        # get timeline media pool item for metadata update
-        timeline_media_pool_item = None
-        for item in lib.iter_all_media_pool_clips():
-            item_name = item.GetName()
-            if item_name != timeline_name:
-                continue
-            timeline_media_pool_item = item
-            break
+        timeline_media_pool_item = lib.get_timeline_media_pool_item(
+            current_timeline
+        )
 
-        # Update the metadata
-        if timeline_media_pool_item:
-            publish_data = {"publish": self.data}
-            timeline_media_pool_item.SetMetadata(
-                lib.pype_tag_name, json.dumps(publish_data)
-            )
-        else:
-            NameError("Timeline not found in media pool.")
+        publish_data = {"publish": self.data}
+
+        timeline_media_pool_item.SetMetadata(
+            lib.pype_tag_name, json.dumps(publish_data)
+        )

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -1,4 +1,3 @@
-from pprint import pformat
 import json
 from ayon_core.pipeline.create.legacy_create import LegacyCreator
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -33,3 +33,5 @@ class CreateEditorialPackage(LegacyCreator):
             timeline_media_pool_item.SetMetadata(
                 lib.pype_tag_name, json.dumps(publish_data)
             )
+        else:
+            NameError("Timeline not found in media pool.")

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -15,16 +15,6 @@ class CreateEditorialPackage(LegacyCreator):
 
     def process(self):
         """Process the creation of the editorial package."""
-        if (self.options or {}).get("useSelection"):
-            # if selected is on then get only timeline from media pool
-            # selection
-            self.convert_timeline_to_editorial_package_instance()
-        else:
-            # if selected is on then get only active timeline
-            self.convert_timeline_to_editorial_package_instance()
-
-    def convert_timeline_to_editorial_package_instance(self):
-        """Convert timeline to editorial package instance."""
         current_timeline = lib.get_current_timeline()
         timeline_name = current_timeline.GetName()
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -17,6 +17,9 @@ class CreateEditorialPackage(LegacyCreator):
         """Process the creation of the editorial package."""
         current_timeline = lib.get_current_timeline()
 
+        if not current_timeline:
+            raise RuntimeError("Make sure to have an active current timeline.")
+
         timeline_media_pool_item = lib.get_timeline_media_pool_item(
             current_timeline
         )

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -1,0 +1,46 @@
+from pprint import pformat
+import json
+from ayon_core.pipeline.create.legacy_create import LegacyCreator
+
+from ayon_resolve.api import lib
+
+
+class CreateEditorialPackage(LegacyCreator):
+    """Create Editorial Package."""
+
+    name = "editorial_pkg"
+    label = "Editorial Package"
+    product_type = "editorial_pkg"
+    icon = "camera"
+    defaults = ["Main"]
+
+    def process(self):
+        """Process the creation of the editorial package."""
+        if (self.options or {}).get("useSelection"):
+            # if selected is on then get only timeline from media pool
+            # selection
+            self.convert_timeline_to_editorial_package_instance()
+        else:
+            # if selected is on then get only active timeline
+            self.convert_timeline_to_editorial_package_instance()
+
+    def convert_timeline_to_editorial_package_instance(self):
+        """Convert timeline to editorial package instance."""
+        current_timeline = lib.get_current_timeline()
+        timeline_name = current_timeline.GetName()
+
+        # get timeline media pool item for metadata update
+        timeline_media_pool_item = None
+        for item in lib.iter_all_media_pool_clips():
+            item_name = item.GetName()
+            if item_name != timeline_name:
+                continue
+            timeline_media_pool_item = item
+            break
+
+        # Update the metadata
+        if timeline_media_pool_item:
+            publish_data = {"publish": self.data}
+            timeline_media_pool_item.SetMetadata(
+                lib.pype_tag_name, json.dumps(publish_data)
+            )

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -61,18 +61,17 @@ class LoadEditorialPackage(load.LoaderPlugin):
             break
 
         # Update the metadata
-        if timeline_media_pool_item:
-            clip_data = self._get_container_data(
-                context, data)
+        clip_data = self._get_container_data(
+            context, data)
 
-            timeline_media_pool_item.SetMetadata(
-                lib.pype_tag_name, json.dumps(clip_data)
-            )
+        timeline_media_pool_item.SetMetadata(
+            lib.pype_tag_name, json.dumps(clip_data)
+        )
 
-            # set clip color based on random choice
-            clip_color = self.get_clip_color()
-            print("Clip color: ", clip_color)
-            timeline_media_pool_item.SetClipColor(clip_color)
+        # set clip color based on random choice
+        clip_color = self.get_clip_color()
+        timeline_media_pool_item.SetClipColor(clip_color)
+
 
         # TODO: there are two ways to import timeline resources (representation
         #   and resources folder) but Resolve seems to ignore any of this
@@ -135,7 +134,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
         return data
 
     def get_clip_color(self):
-        """Return clip color based on version data."""
+        """Return clip color."""
 
         # list of all available davinci resolve clip colors
         colors = [

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -41,7 +41,11 @@ class LoadEditorialPackage(load.LoaderPlugin):
         # create versioned bin for editorial package
         version_name = context["version"]["name"]
         loaded_bin = lib.create_bin(f"{folder_path}/{name}/{version_name}")
-        loaded_timeline_name = f"{name}_{version_name}_timeline"
+
+        # make timeline unique name based on folder path
+        folder_path_name = folder_path.replace("/", "_").lstrip("_")
+        loaded_timeline_name = (
+            f"{folder_path_name}_{name}_{version_name}_timeline")
         import_options = {
             "timelineName": loaded_timeline_name,
             "importSourceClips": True,
@@ -75,6 +79,9 @@ class LoadEditorialPackage(load.LoaderPlugin):
         print("Timeline imported: ", timeline)
 
     def update(self, container, context):
+        timeline_mp_clip = container["_item"]
+        timeline_mp_clip.SetMetadata(lib.pype_tag_name, "")
+
         self.load(
             context,
             context["product"]["name"],

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -69,7 +69,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
         )
 
         # set clip color based on random choice
-        clip_color = self.get_clip_color()
+        clip_color = self.get_random_clip_color()
         timeline_media_pool_item.SetClipColor(clip_color)
 
         # TODO: there are two ways to import timeline resources (representation
@@ -132,7 +132,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
 
         return data
 
-    def get_clip_color(self):
+    def get_random_clip_color(self):
         """Return clip color."""
 
         # list of all available davinci resolve clip colors

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -72,7 +72,6 @@ class LoadEditorialPackage(load.LoaderPlugin):
         clip_color = self.get_clip_color()
         timeline_media_pool_item.SetClipColor(clip_color)
 
-
         # TODO: there are two ways to import timeline resources (representation
         #   and resources folder) but Resolve seems to ignore any of this
         #   since it is importing sources automatically. But we might need

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -1,11 +1,15 @@
+import json
 from pathlib import Path
+import random
 
 from ayon_core.pipeline import (
+    AVALON_CONTAINER_ID,
     load,
     get_representation_path,
 )
 
 from ayon_resolve.api import lib
+from ayon_resolve.api.plugin import get_editorial_publish_data
 
 
 class LoadEditorialPackage(load.LoaderPlugin):
@@ -32,21 +36,126 @@ class LoadEditorialPackage(load.LoaderPlugin):
 
         project = lib.get_current_project()
         media_pool = project.GetMediaPool()
+        folder_path = context["folder"]["path"]
 
         # create versioned bin for editorial package
         version_name = context["version"]["name"]
-        bin_name = f"{name}_{version_name}"
-        lib.create_bin(bin_name)
-
+        loaded_bin = lib.create_bin(f"{folder_path}/{name}/{version_name}")
+        loaded_timeline_name = f"{name}_{version_name}_timeline"
         import_options = {
-            "timelineName": "Editorial Package Timeline",
+            "timelineName": loaded_timeline_name,
             "importSourceClips": True,
             "sourceClipsPath": search_folder_path.as_posix(),
         }
 
+        # import timeline from otio file
         timeline = media_pool.ImportTimelineFromFile(files, import_options)
+
+        # get timeline media pool item for metadata update
+        timeline_media_pool_item = None
+        for item in lib.iter_all_media_pool_clips(root=loaded_bin):
+            item_name = item.GetName()
+            if item_name != loaded_timeline_name:
+                continue
+            timeline_media_pool_item = item
+            break
+
+        # Update the metadata
+        if timeline_media_pool_item:
+            clip_data = self._get_container_data(
+                context, data)
+
+            timeline_media_pool_item.SetMetadata(
+                lib.pype_tag_name, json.dumps(clip_data)
+            )
+
+            # set clip color based on random choice
+            clip_color = self.get_clip_color()
+            print("Clip color: ", clip_color)
+            timeline_media_pool_item.SetClipColor(clip_color)
+
+        # TODO: there are two ways to import timeline resources (representation
+        #   and resources folder) but Resolve seems to ignore any of this
+        #   since it is importing sources automatically. But we might need
+        #   to at least set some metadata to those loaded media pool items
         print("Timeline imported: ", timeline)
 
     def update(self, container, context):
-        # TODO: implement update method in future
-        pass
+        self.load(
+            context,
+            context["product"]["name"],
+            container["namespace"],
+            container
+        )
+
+    def _get_container_data(
+        self,
+        context: dict,
+        data: dict
+    ) -> dict:
+        """Return metadata related to the representation and version."""
+
+        # add additional metadata from the version to imprint AYON knob
+        version_entity = context["version"]
+
+        # remove unnecessary keys from the data
+        for key in ["_item", "name"]:
+            if key not in data:
+                continue
+            data.pop(key)
+
+        data = {
+            "load": data,
+        }
+
+        # add version attributes to the load data
+        data["load"].update(
+            version_entity["attrib"]
+        )
+
+        # add variables related to version context
+        data["load"].update(
+            {
+                "schema": "ayon:container-3.0",
+                "id": AVALON_CONTAINER_ID,
+                "loader": str(self.__class__.__name__),
+                "author": version_entity["data"]["author"],
+                "representation": context["representation"]["id"],
+                "version": version_entity["version"],
+            }
+        )
+
+        # add publish data for streamline publishing
+        data["publish"] = get_editorial_publish_data(
+            folder_path=context["folder"]["path"],
+            product_name=context["product"]["name"],
+            version=version_entity["version"],
+        )
+
+        return data
+
+    def get_clip_color(self):
+        """Return clip color based on version data."""
+
+        # list of all available davinci resolve clip colors
+        colors = [
+            "Orange",
+            "Apricot"
+            "Yellow",
+            "Lime",
+            "Olive",
+            "Green",
+            "Teal",
+            "Navy",
+            "Blue",
+            "Purple",
+            "Violet",
+            "Pink",
+            "Tan",
+            "Beige",
+            "Brown",
+            "Chocolate",
+        ]
+
+        # return one of the colors based on random position
+        return random.choice(colors)

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -52,13 +52,9 @@ class LoadEditorialPackage(load.LoaderPlugin):
         timeline = media_pool.ImportTimelineFromFile(files, import_options)
 
         # get timeline media pool item for metadata update
-        timeline_media_pool_item = None
-        for item in lib.iter_all_media_pool_clips(root=loaded_bin):
-            item_name = item.GetName()
-            if item_name != loaded_timeline_name:
-                continue
-            timeline_media_pool_item = item
-            break
+        timeline_media_pool_item = lib.get_timeline_media_pool_item(
+            timeline, loaded_bin
+        )
 
         # Update the metadata
         clip_data = self._get_container_data(

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -99,11 +99,8 @@ class LoadEditorialPackage(load.LoaderPlugin):
         # add additional metadata from the version to imprint AYON knob
         version_entity = context["version"]
 
-        # remove unnecessary keys from the data
-        for key in ["_item", "name"]:
-            if key not in data:
-                continue
-            data.pop(key)
+        for key in ("_item", "name"):
+            data.pop(key, None)  # remove unnecessary key from the data if it exists
 
         data = {
             "load": data,


### PR DESCRIPTION
We've upgraded the loader in several ways:

*   The timeline now includes a `VFX data` JSON string with Load and Publish metadata.
*   Each timeline is randomly assigned one of the available clip colors.
*   The update function ensures that the newest version is loaded into the media pool.
*   Timelines are organized into hierarchical bins, each with a dedicated version bin.
*   Manager Tool can easily list timelines within containers.

# Testing steps
1. Use Traypublisher and publish couple times Editorial Package folder here is testing of ynput internal files (sensitive data) https://drive.google.com/open?id=1XbYdnblAuYuCYPaEBd48iSHhbcfjiOPm&usp=drive_fs
2. Open Resolve and Loader
3. Load the editorial_pkg product in lower version so you can version manage via Manager
4. After it is loaded and version updated notice there are multiple version folders and each of timeline is having different clip color assigned. 

