### PR TITLE
Refactor timing variables check for None values

### DIFF
--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -282,7 +282,11 @@ def create_timeline_item(
     timeline = timeline or get_current_timeline()
 
     # timing variables
-    if all([timeline_in, source_start, source_end]):
+    if all([
+        timeline_in is not None,
+        source_start is not None,
+        source_end is not None
+    ]):
         fps = timeline.GetSetting("timelineFrameRate")
         duration = source_end - source_start
         timecode_in = frames_to_timecode(timeline_in, fps)


### PR DESCRIPTION
Adjusted the check for None values in timing variables to ensure all required parameters are present before proceeding with calculations.

Testing steps:
- open resolve at at any timeline
- make sure you are having activated empty track
- open loader and load any clip which was previously published from editorial on particular clipIN/OUT position (or just set some frames in shot folder attributes)
