### PR TITLE
Transfer editorial package to new publisher

### DIFF
--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -707,6 +707,7 @@ def get_editorial_publish_data(
         folder_path (str): Folder path where editorial package is located.
         product_name (str): Editorial product name.
         version (Optional[str]): Editorial product version. Defaults to None.
+        task (Optional[str]): Associated task name. Defaults to None (no task).
 
     Returns:
         dict: Editorial publish data.

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -1,4 +1,4 @@
-import copy 
+import copy
 import re
 import uuid
 
@@ -8,7 +8,7 @@ from ayon_core.pipeline.constants import AVALON_INSTANCE_ID
 from ayon_core.pipeline import (
     LoaderPlugin,
     Creator,
-    HiddenCreator,    
+    HiddenCreator,
     Anatomy
 )
 
@@ -698,7 +698,8 @@ class ResolvePublishCreator(Creator):
 def get_editorial_publish_data(
     folder_path,
     product_name,
-    version=None
+    version=None,
+    task=None,
 ) -> dict:
     """Get editorial publish data from context.
 
@@ -722,6 +723,9 @@ def get_editorial_publish_data(
 
     if version:
         data["version"] = version
+
+    if task:
+        data["task"] = task
 
     return data
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -53,7 +53,7 @@ class CreateEditorialPackage(ResolveCreator):
 
         new_instance = CreatedInstance(
             self.product_type,
-            publish_data["publish"]["productName"],
+            product_name,
             publish_data,
             self,
         )

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -16,15 +16,15 @@ class CreateEditorialPackage(ResolveCreator):
     icon = "camera"
     defaults = ["Main"]
 
-    def create(self, subset_name, instance_data, pre_create_data):
+    def create(self, product_name, instance_data, pre_create_data):
         """Create a new editorial_pkg instance.
 
         Args:
-            subset_name (str): The subset name
+            product_name (str): The subset name
             instance_data (dict): The instance data.
             pre_create_data (dict): The pre_create context data.
         """
-        super().create(subset_name,
+        super().create(product_name,
                        instance_data,
                        pre_create_data)
 
@@ -39,13 +39,6 @@ class CreateEditorialPackage(ResolveCreator):
 
         publish_data = deepcopy(instance_data)
 
-        # add publish data for streamlrine publishing
-        product_name = self.get_product_name(
-            self.project_name,
-            self.create_context.get_current_folder_entity(),
-            self.create_context.get_current_task_entity(),
-            instance_data["variant"],
-        )
         publish_data["publish"] = get_editorial_publish_data(
             folder_path=instance_data["folderPath"],
             product_name=product_name,

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -20,9 +20,9 @@ class CreateEditorialPackage(ResolveCreator):
     def create(self, subset_name, instance_data, pre_create_data):
         """
         """
-        super(CreateEditorialPackage, self).create(subset_name,
-                                           instance_data,
-                                           pre_create_data)
+        super().create(subset_name,
+                       instance_data,
+                       pre_create_data)
 
         current_timeline = lib.get_current_timeline()
 
@@ -74,7 +74,7 @@ class CreateEditorialPackage(ResolveCreator):
 
             # exclude all which are not productType editorial_pkg
             if (
-                data.get("publish", {}).get("productType") != "editorial_pkg"
+                data.get("publish", {}).get("productType") != self.product_type
             ):
                 continue
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -1,88 +1,120 @@
 import json
 from copy import deepcopy
-from ayon_core.tools.context_dialog.window import (
-    ContextDialog,
-    ContextDialogController
-)
-from ayon_core.pipeline import get_current_project_name
-from ayon_api import get_folder_by_id, get_task_by_id, get_folder_by_path
-from ayon_core.pipeline.create.legacy_create import LegacyCreator
+
+from ayon_core.pipeline.create import CreatorError, CreatedInstance
 
 from ayon_resolve.api import lib, constants
-from ayon_resolve.api.plugin import get_editorial_publish_data
+from ayon_resolve.api.plugin import ResolveCreator, get_editorial_publish_data
 
 
-class CreateEditorialPackage(LegacyCreator):
+class CreateEditorialPackage(ResolveCreator):
     """Create Editorial Package."""
 
-    name = "editorial_pkg"
+    identifier = "io.ayon.creators.resolve.editorial_pkg"
+    product_name = "editorial_pkgMain"
     label = "Editorial Package"
     product_type = "editorial_pkg"
     icon = "camera"
     defaults = ["Main"]
 
-    def process(self):
-        """Process the creation of the editorial package."""
-        project_name = get_current_project_name()
-        folder_path = self.data["folderPath"]
-
-        current_folder = get_folder_by_path(project_name, folder_path)
-        print(current_folder)
+    def create(self, subset_name, instance_data, pre_create_data):
+        """
+        """
+        super(CreateEditorialPackage, self).create(subset_name,
+                                           instance_data,
+                                           pre_create_data)
 
         current_timeline = lib.get_current_timeline()
 
-        context = ask_for_context(
-            project_name, current_folder["id"]
-        )
-
-        if context is None:
-            return
-
-        # Get workfile path to save to.
-        project_name = context["project_name"]
-        folder = get_folder_by_id(project_name, context["folder_id"])
-
-        # task is optional so we need to check if it is set
-        task = None
-        if "task_id" in context:
-            task = get_task_by_id(project_name, context["task_id"])
-
-        # reset self.data to be pointing in the set context data
-        self.data["folderPath"] = folder["path"]
-
-        if task:
-            self.data.update({
-                "taskId": task["id"],
-                "taskName": task["name"],
-            })
-
         if not current_timeline:
-            raise RuntimeError("Make sure to have an active current timeline.")
+            raise CreatorError("Make sure to have an active current timeline.")
 
         timeline_media_pool_item = lib.get_timeline_media_pool_item(
             current_timeline
         )
 
-        publish_data = deepcopy(self.data)
+        publish_data = deepcopy(instance_data)
+
         # add publish data for streamline publishing
         publish_data["publish"] = get_editorial_publish_data(
-            folder_path=folder["path"],
-            product_name=self.data["productName"],
+            folder_path=instance_data["folderPath"],
+            product_name=self.product_name,
         )
 
+        publish_data["label"] = current_timeline.GetName()
         timeline_media_pool_item.SetMetadata(
             constants.AYON_TAG_NAME, json.dumps(publish_data)
         )
 
+        publish_data["media_pool_item_id"] = timeline_media_pool_item.GetUniqueId()
+        new_instance = CreatedInstance(
+            self.product_type,
+            self.product_name,
+            publish_data,
+            self,
+        )
+        new_instance.transient_data["timeline_item"] = timeline_media_pool_item
+        self._add_instance_to_context(new_instance)
 
-def ask_for_context(
-    project_name, folder_id
-):
-    """Ask for context to create Editorial Package."""
-    controller = ContextDialogController()
-    window = ContextDialog(controller=controller)
-    controller.set_expected_selection(
-        project_name, folder_id)
-    window.exec_()
+    def collect_instances(self):
+        """Collect all created instances from current timeline."""
+        for media_pool_item in lib.iter_all_media_pool_clips():
+            data = media_pool_item.GetMetadata(constants.AYON_TAG_NAME)
+            if not data:
+                continue
 
-    return controller.get_selected_context()
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                self.log.warning(
+                    f"Failed to parse json data from media pool item: "
+                    f"{media_pool_item.GetName()}"
+                )
+                continue
+
+            # exclude all which are not productType editorial_pkg
+            if (
+                data.get("publish", {}).get("productType") != "editorial_pkg"
+            ):
+                continue
+
+            data["media_pool_item_id"] = media_pool_item.GetUniqueId()
+            current_instance = CreatedInstance(
+                self.product_type,
+                self.product_name,
+                data,
+                self
+            )
+
+            current_instance.transient_data["timeline_item"] = media_pool_item            
+            self._add_instance_to_context(current_instance)
+
+    def update_instances(self, update_list):
+        """Store changes of existing instances so they can be recollected.
+
+        Args:
+            update_list(List[UpdateData]): Gets list of tuples. Each item
+                contain changed instance and it's changes.
+        """
+        for created_inst, _changes in update_list:
+            timeline_media_pool_item = created_inst.transient_data["timeline_item"]
+            timeline_media_pool_item.SetMetadata(
+                constants.AYON_TAG_NAME,
+                json.dumps(created_inst.data_to_store()),
+            )
+
+    def remove_instances(self, instances):
+        """Remove instance marker from track item.
+
+        Args:
+            instance(List[CreatedInstance]): Instance objects which should be
+                removed.
+        """
+        for instance in instances:
+            self._remove_instance_from_context(instance)
+            timeline_media_pool_item = instance.transient_data["timeline_item"]
+            timeline_media_pool_item.SetMetadata(
+                constants.AYON_TAG_NAME,
+                json.dumps({}),
+            )
+

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -86,11 +86,9 @@ class CreateEditorialPackage(ResolveCreator):
 
             publish_data = data["publish"]
 
-            # TODO: backward compatibility for legacy workflow instances
             # add label into instance data in case it is missing in publish
-            # data
-            if "label" not in publish_data:
-                publish_data["label"] = media_pool_item.GetName()
+            # data (legacy publish) or timeline was renamed.
+            publish_data["label"] = media_pool_item.GetName()
 
             # TODO: backward compatibility for legacy workflow instances
             # add variant into instance data in case it is missing in publish

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -8,7 +8,7 @@ from ayon_core.pipeline import get_current_project_name
 from ayon_api import get_folder_by_id, get_task_by_id, get_folder_by_path
 from ayon_core.pipeline.create.legacy_create import LegacyCreator
 
-from ayon_resolve.api import lib
+from ayon_resolve.api import lib, constants
 from ayon_resolve.api.plugin import get_editorial_publish_data
 
 
@@ -71,7 +71,7 @@ class CreateEditorialPackage(LegacyCreator):
         )
 
         timeline_media_pool_item.SetMetadata(
-            lib.pype_tag_name, json.dumps(publish_data)
+            constants.AYON_TAG_NAME, json.dumps(publish_data)
         )
 
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -73,8 +73,8 @@ class CreateEditorialPackage(ResolveCreator):
                 data = json.loads(data)
             except json.JSONDecodeError:
                 self.log.warning(
-                    f"Failed to parse json data from media pool item: "
-                    f"{media_pool_item.GetName()}"
+                    "Failed to parse json data from media pool item: %s",
+                    media_pool_item.GetName()
                 )
                 continue
 

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -20,7 +20,7 @@ class CreateEditorialPackage(ResolveCreator):
         """Create a new editorial_pkg instance.
 
         Args:
-            product_name (str): The subset name
+            product_name (str): The product name
             instance_data (dict): The instance data.
             pre_create_data (dict): The pre_create context data.
         """

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -8,7 +8,7 @@ from ayon_core.pipeline import (
     get_representation_path,
 )
 
-from ayon_resolve.api import lib
+from ayon_resolve.api import lib, constants
 from ayon_resolve.api.plugin import get_editorial_publish_data
 
 
@@ -67,7 +67,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
             context, data)
 
         timeline_media_pool_item.SetMetadata(
-            lib.pype_tag_name, json.dumps(clip_data)
+            constants.AYON_TAG_NAME, json.dumps(clip_data)
         )
 
         # set clip color based on random choice
@@ -86,7 +86,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
         # Get the latest version of the container data
         timeline_media_pool_item = container["_item"]
         clip_data = timeline_media_pool_item.GetMetadata(
-            lib.pype_tag_name)
+            constants.AYON_TAG_NAME)
         clip_data = json.loads(clip_data)
 
         clip_data["load"] = {}
@@ -96,7 +96,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
             clip_data["publish"]["publish"] = False
 
         timeline_media_pool_item.SetMetadata(
-            lib.pype_tag_name, json.dumps(clip_data))
+            constants.AYON_TAG_NAME, json.dumps(clip_data))
 
         self.load(
             context,

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -112,6 +112,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
     ) -> dict:
         """Return metadata related to the representation and version."""
 
+        representation = context["representation"]
         # add additional metadata from the version to imprint AYON knob
         version_entity = context["version"]
 
@@ -144,6 +145,8 @@ class LoadEditorialPackage(load.LoaderPlugin):
             folder_path=context["folder"]["path"],
             product_name=context["product"]["name"],
             version=version_entity["version"],
+            task=context["representation"]["context"].get("task", {}).get(
+                "name"),
         )
 
         return data

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -16,12 +16,7 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
         project_name = instance.context.data["projectName"]
         self.log.info(f"project: {project_name}")
 
-        media_pool_item_id = instance.data["media_pool_item_id"]
-        for media_pool_item in lib.iter_all_media_pool_clips():
-            if media_pool_item.GetUniqueId() == media_pool_item_id:
-                break
-        else:
-            raise RuntimeError("Could not identify media pool item from instance.")
+        media_pool_item = instance.data["transientData"]["timeline_pool_item"]
 
         # get version from publish data and rise it one up
         version = instance.data.get("version")

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -1,88 +1,56 @@
-import json
-
 import pyblish.api
 
 import ayon_api
-from ayon_api import get_task_by_id
 
 from ayon_resolve.api import lib, constants
 
 
-class EditorialPackageInstances(pyblish.api.ContextPlugin):
+class EditorialPackageInstances(pyblish.api.InstancePlugin):
     """Collect all Track items selection."""
 
     order = pyblish.api.CollectorOrder - 0.49
     label = "Collect Editorial Package Instances"
     families = ["editorial_pkg"]
 
-    def process(self, context):
-        project_name = context.data["projectName"]
+    def process(self, instance):
+        project_name = instance.context.data["projectName"]
         self.log.info(f"project: {project_name}")
 
+        media_pool_item_id = instance.data["media_pool_item_id"]
         for media_pool_item in lib.iter_all_media_pool_clips():
+            if media_pool_item.GetUniqueId() == media_pool_item_id:
+                break
+        else:
+            raise RuntimeError("Could not identify media pool item from instance.")
 
-            data = media_pool_item.GetMetadata(constants.AYON_TAG_NAME)
-            if not data:
-                continue
+        # get version from publish data and rise it one up
+        version = instance.data.get("version")
+        if version is not None:
+            version += 1
 
-            try:
-                data = json.loads(data)
-            except json.JSONDecodeError:
-                self.log.warning(
-                    f"Failed to parse json data from media pool item: "
-                    f"{media_pool_item.GetName()}"
-                )
-                continue
-
-            # exclude all which are not productType editorial_pkg
-            if (
-                data.get("publish")
-                and data["publish"].get("productType") != "editorial_pkg"
-            ):
-                continue
-
-            instance = context.create_instance(name=media_pool_item.GetName())
-
-            publish_data = data["publish"]
-
-            # get version from publish data and rise it one up
-            version = publish_data.get("version")
-            if version is not None:
-                version += 1
-
-                # make sure last version of product is higher than current
-                # expected current version from publish data
-                folder_entity = ayon_api.get_folder_by_path(
-                    project_name=project_name,
-                    folder_path=publish_data["folderPath"],
-                )
-                last_version = ayon_api.get_last_version_by_product_name(
-                    project_name=project_name,
-                    product_name=publish_data["productName"],
-                    folder_id=folder_entity["id"],
-                )
-                if last_version is not None:
-                    last_version = int(last_version["version"])
-                    if version <= last_version:
-                        version = last_version + 1
-
-                publish_data["version"] = version
-
-            publish_data.update(
-                {
-                    "mediaPoolItem": media_pool_item,
-                    "item": media_pool_item,
-                }
+            # make sure last version of product is higher than current
+            # expected current version from publish data
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name=project_name,
+                folder_path=publish_data["folderPath"],
             )
+            last_version = ayon_api.get_last_version_by_product_name(
+                project_name=project_name,
+                product_name=publish_data["productName"],
+                folder_id=folder_entity["id"],
+            )
+            if last_version is not None:
+                last_version = int(last_version["version"])
+                if version <= last_version:
+                    version = last_version + 1
 
-            if publish_data.get("taskId"):
-                task_entity = get_task_by_id(
-                    project_name=project_name,
-                    task_id=publish_data["taskId"],
-                )
-                publish_data["taskEntity"] = task_entity
-                publish_data["task"] = task_entity["name"]
+            instance.data["version"] = version
 
-            instance.data.update(publish_data)
+        instance.data.update(
+            {
+                "mediaPoolItem": media_pool_item,
+                "item": media_pool_item,
+            }
+        )
 
-            self.log.info(f"Editorial Package: {instance.data}")
+        self.log.info(f"Editorial Package: {instance.data}")

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -27,11 +27,11 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
             # expected current version from publish data
             folder_entity = ayon_api.get_folder_by_path(
                 project_name=project_name,
-                folder_path=publish_data["folderPath"],
+                folder_path=instance.data["folderPath"],
             )
             last_version = ayon_api.get_last_version_by_product_name(
                 project_name=project_name,
-                product_name=publish_data["productName"],
+                product_name=instance.data["productName"],
                 folder_id=folder_entity["id"],
             )
             if last_version is not None:

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -5,7 +5,7 @@ import pyblish.api
 import ayon_api
 from ayon_api import get_task_by_id
 
-from ayon_resolve.api import lib
+from ayon_resolve.api import lib, constants
 
 
 class EditorialPackageInstances(pyblish.api.ContextPlugin):
@@ -21,7 +21,7 @@ class EditorialPackageInstances(pyblish.api.ContextPlugin):
 
         for media_pool_item in lib.iter_all_media_pool_clips():
 
-            data = media_pool_item.GetMetadata(lib.pype_tag_name)
+            data = media_pool_item.GetMetadata(constants.AYON_TAG_NAME)
             if not data:
                 continue
 

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -18,9 +18,14 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
 
         media_pool_item = instance.data["transientData"]["timeline_pool_item"]
 
-        # get version from publish data and rise it one up
+        # Special case for versioning editorial_pkg products:
+        # * instance created by creator: version up as usual
+        # * instance created from loader: loaded version is added 
+        #   into the instance by loader. Then version up from initial pkg
+        #   to keep 'chained' version across tasks/product when possible.
         version = instance.data.get("version")
         if version is not None:
+            # get version from publish data and rise it one up
             version += 1
 
             # make sure last version of product is higher than current

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -48,4 +48,4 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
             }
         )
 
-        self.log.info(f"Editorial Package: {instance.data}")
+        self.log.debug(f"Editorial Package: {instance.data}")


### PR DESCRIPTION
## Changelog Description
Transfer `editorial_pkg` creator to new publisher.
This contains changes from #12. 

_Note_ this is backward-compatible with previously save scene and published packages as metadata remains store under the same key `VFX Notes` which used to be referenced as `api.lib.pype_tag_name` but now becomes `api.constants.AYON_TAG_NAME`

## Additional info
![10-07-2024 (15-10-28)](https://github.com/user-attachments/assets/d8a5c04d-25a1-4d6f-ac6b-bf790931d0af)

## Testing notes:

1. Create a timeline
2. Select this timeline
3. Create a new `editorial pkg` from `AYON Menu` using `Editorial Package` creator
4. Publish it
5. Load the published timeline using the Loader
