### PR TITLE
Fix custom AYON OTIO export range mismatches.

### DIFF
--- a/client/ayon_resolve/otio/davinci_export.py
+++ b/client/ayon_resolve/otio/davinci_export.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import sys
 import json
 import opentimelineio as otio
 from . import utils


### PR DESCRIPTION
## Changelog Description

resolve #31 
When working with the new publisher, we found out some mismatch between OTIO native exporter ranges and custom AYON ones. This PR fixes this.

## Additional info
In details the mismatches were:
* potential embedded timecode not detected for movie and image sequence
* Gap clip source range not starting from 0 but record range in parent
* timeline fps override not detected
* marker source range not remapped to clip available range
* media source ranges not rescaled when timeline fps != source media fps

**This PR focuses on making the ranges consistent between both exporters. It does not report all potential mismatch when exporting metadata, effects, names, ...**

## Testing notes:

1. Export a timeline using custom AYON OTIO exporter
```python
from ayon_resolve.api import lib
from ayon_resolve.otio import davinci_export as otio_export

otio_timeline = otio_export.create_otio_timeline(
  lib.get_current_resolve_project(),
  timeline=lib.get_current_timeline()
)
otio_export.write_to_file(otio_timeline, filepath)
```
2. Export the same timeline using native OTIO exporter (Resolve >= 18.5)
```python
from ayon_resolve.api import bmdvr, lib

timeline = lib.get_current_timeline()
timeline.Export("C:\\path\\to\\export_native.otio", bmdvr.EXPORT_OTIO)
```
3. Compare the resulting files and ensure clips' `source_range` and `available_range` match

4. My own test cases and results can be found here:
* [qt_and_qt_embedded_tc.zip](https://github.com/user-attachments/files/17403494/qt_and_qt_embedded_tc.zip)
* [img_seq_timeline_25fps_source_24fps.zip](https://github.com/user-attachments/files/17403495/img_seq_timeline_25fps_source_24fps.zip)
* [img_seq_timeline_24fps_source_24fps.zip](https://github.com/user-attachments/files/17403497/img_seq_timeline_24fps_source_24fps.zip)
* [export_gap_and_markers.zip](https://github.com/user-attachments/files/17403501/export_gap_and_markers.zip)
