### PR TITLE
Fix bugs: distribution of otioClip attributes to plates + native OTIO export support

### DIFF
--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -1101,6 +1101,10 @@ def export_timeline_otio_to_file(timeline, filepath):
     """
     try:
         from . import bmdvr
+
+        if bmdvr.EXPORT_OTIO is None:
+            raise AttributeError("Unsupported native Export OTIO")
+
         timeline.Export(filepath, bmdvr.EXPORT_OTIO)
 
     except Exception as error:

--- a/client/ayon_resolve/plugins/publish/collect_plates.py
+++ b/client/ayon_resolve/plugins/publish/collect_plates.py
@@ -1,4 +1,6 @@
-import pyblish
+import pyblish.api
+
+from ayon_resolve.otio import utils
 
 
 class CollectPlate(pyblish.api.InstancePlugin):
@@ -15,6 +17,15 @@ class CollectPlate(pyblish.api.InstancePlugin):
             instance (pyblish.Instance): The shot instance to update.
         """
         instance.data["families"].append("clip")
+
+        otio_timeline = instance.context.data["otioTimeline"]
+        otio_clip, marker = utils.get_marker_from_clip_index(
+            otio_timeline, instance.data["clip_index"]
+        )
+        if not otio_clip:
+            raise RuntimeError("Could not retrieve otioClip for shot %r", instance)
+
+        instance.data["otioClip"] = otio_clip
 
         # Retrieve instance data from parent instance shot instance.
         parent_instance_id = instance.data["parent_instance_id"]

--- a/client/ayon_resolve/plugins/publish/collect_shots.py
+++ b/client/ayon_resolve/plugins/publish/collect_shots.py
@@ -15,7 +15,6 @@ class CollectShot(pyblish.api.InstancePlugin):
     SHARED_KEYS = (
         "folderPath",
         "fps",
-        "otioClip",
         "resolutionWidth",
         "resolutionHeight",
         "pixelAspect",        

--- a/client/ayon_resolve/plugins/publish/collect_shots.py
+++ b/client/ayon_resolve/plugins/publish/collect_shots.py
@@ -15,6 +15,7 @@ class CollectShot(pyblish.api.InstancePlugin):
     SHARED_KEYS = (
         "folderPath",
         "fps",
+        "otioClip",
         "resolutionWidth",
         "resolutionHeight",
         "pixelAspect",        


### PR DESCRIPTION
## Changelog Description

* report https://github.com/ynput/ayon-hiero/pull/31 (hiero) bugfix for Resolve.
* ensure native OTIO support is properly detected

## Testing notes:
1. Create timeline in Resolve with vertically aligned shots in multiple tracks. Make sure media resources for each clip is different.
2. Rename tracks to hold some unique names
3. select shots which are vertically aligned
4. go to AYON menu and Create
5. enamble vertical sync
6. Select hero track 
7. Hit Create and then Publish.
8. Note the integrated files and ensure plate version is having correct representation files. 
