### PR TITLE
AY-7222 Make editorial package reviewable

### DIFF
--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -2,9 +2,20 @@ import json
 from copy import deepcopy
 
 from ayon_core.pipeline.create import CreatorError, CreatedInstance
+from ayon_core.lib import BoolDef
 
 from ayon_resolve.api import lib, constants
 from ayon_resolve.api.plugin import ResolveCreator, get_editorial_publish_data
+
+
+_CREATE_ATTR_DEFS = [
+    BoolDef(
+        "review",
+        label="Make intermediate media reviewable",
+        tooltip="Make editorial package intermediate media reviewable.",
+        default=False,
+    )
+]
 
 
 class CreateEditorialPackage(ResolveCreator):
@@ -15,6 +26,28 @@ class CreateEditorialPackage(ResolveCreator):
     product_type = "editorial_pkg"
     icon = "camera"
     defaults = ["Main"]
+
+    def get_pre_create_attr_defs(self):
+        """Plugin attribute definitions needed for creation.
+
+        Returns:
+            list[AbstractAttrDef]: Attribute definitions that can be tweaked
+                for created instance.
+        """
+        return _CREATE_ATTR_DEFS
+
+    def get_attr_defs_for_instance(self, instance):
+        """Get attribute definitions for an instance.
+
+        Args:
+            instance (CreatedInstance): Instance for which to get
+                attribute definitions.
+
+        Returns:
+            list[AbstractAttrDef]: Attribute definitions that can be tweaked
+                for created instance.
+        """
+        return _CREATE_ATTR_DEFS
 
     def create(self, product_name, instance_data, pre_create_data):
         """Create a new editorial_pkg instance.
@@ -36,6 +69,10 @@ class CreateEditorialPackage(ResolveCreator):
         timeline_media_pool_item = lib.get_timeline_media_pool_item(
             current_timeline
         )
+
+        instance_data["creator_attributes"] = {
+            "review": pre_create_data["review"]
+        }
 
         tag_metadata = {
             "publish": deepcopy(instance_data),

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -56,6 +56,11 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
                     "frameEnd": timeline.GetEndFrame()
                 }
             )
-        instance.data["families"].append("review")
+
+        # Shall the instance produce reviewable representation ?
+        creator_attributes = instance.data.get("creator_attributes", {})
+        reviewable = creator_attributes.pop("review", False)
+        if reviewable:
+            instance.data["families"].append("review")
 
         self.log.debug(f"Editorial Package: {instance.data}")

--- a/client/ayon_resolve/plugins/publish/collect_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/collect_editorial_package.py
@@ -2,6 +2,8 @@ import pyblish.api
 
 import ayon_api
 
+from ayon_resolve.api.lib import maintain_current_timeline
+
 
 class EditorialPackageInstances(pyblish.api.InstancePlugin):
     """Collect all Track items selection."""
@@ -44,11 +46,16 @@ class EditorialPackageInstances(pyblish.api.InstancePlugin):
 
             instance.data["version"] = version
 
-        instance.data.update(
-            {
-                "mediaPoolItem": media_pool_item,
-                "item": media_pool_item,
-            }
-        )
+        with maintain_current_timeline(media_pool_item) as timeline:
+            instance.data.update(
+                {
+                    "mediaPoolItem": media_pool_item,
+                    "item": media_pool_item,
+                    "fps": timeline.GetSetting("timelineFrameRate"),
+                    "frameStart": timeline.GetStartFrame(),
+                    "frameEnd": timeline.GetEndFrame()
+                }
+            )
+        instance.data["families"].append("review")
 
         self.log.debug(f"Editorial Package: {instance.data}")

--- a/client/ayon_resolve/plugins/publish/extract_intermediate_representation.py
+++ b/client/ayon_resolve/plugins/publish/extract_intermediate_representation.py
@@ -66,12 +66,13 @@ class ExtractIntermediateRepresentation(publish.Extractor):
 
         self.log.debug(f"Rendered file: {rendered_file}")
 
-        # create drp workfile representation
+        # create intermediate workfile representation
         representation_intermediate = {
             "name": "intermediate",
             "ext": os.path.splitext(rendered_file)[1][1:],
             "files": rendered_file.name,
             "stagingDir": staging_dir,
+            "tags": ["review"]
         }
         self.log.debug(f"Video representation: {representation_intermediate}")
         instance.data["representations"].append(representation_intermediate)


### PR DESCRIPTION
## Changelog Description
resolve #44
Make the editorial pckg intermediate media reviewable.

This PR needs to be tested alongside: https://github.com/ynput/ayon-core/pull/1041

## Testing notes:
1. Ensure some reviewable setup is configured for Resolve
![image](https://github.com/user-attachments/assets/08538e1a-e775-4378-81bb-8016224cc18a)
2. Open a timeline in Resolve and publish an editorial package from it
3. Ensure the intermediate media is properly processed as a reviewable
![image](https://github.com/user-attachments/assets/1788642a-feab-470c-9c57-08e059b795c3)

