### PR TITLE
Expose sourceResolution as creator_attribute for shot instance.

### DIFF
--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -728,23 +728,23 @@ OTIO file.
         """
         creator = self.create_context.creators[creator_id]
 
-        if creator_id == "":
+        if creator_id == "io.ayon.creators.resolve.shot":
             track_item_duration = timeline_item.GetDuration()
             workfileFrameStart = data["workfileFrameStart"]
             creator_attributes = {
                 "workfileFrameStart": workfileFrameStart,
-                "handleStart": sub_instance_data["handleStart"],
-                "handleEnd": sub_instance_data["handleEnd"],
+                "handleStart": data["handleStart"],
+                "handleEnd": data["handleEnd"],
                 "frameStart": workfileFrameStart,
                 "frameEnd": (workfileFrameStart +
-                    timeline_item),
+                    track_item_duration),
                 "clipIn": timeline_item.GetStart(),
                 "clipOut": timeline_item.GetEnd(),
                 "clipDuration": track_item_duration,
                 "sourceIn": timeline_item.GetLeftOffset(),
                 "sourceOut": (timeline_item.GetLeftOffset() +
                     track_item_duration),
-                "sourceResolution": sub_instance_data["sourceResolution"],
+                "sourceResolution": data["sourceResolution"],
             }
             data["creator_attributes"] = creator_attributes
 

--- a/client/ayon_resolve/plugins/publish/collect_shots.py
+++ b/client/ayon_resolve/plugins/publish/collect_shots.py
@@ -72,7 +72,8 @@ class CollectShot(pyblish.api.InstancePlugin):
         inst_data = marker.metadata["resolve_sub_products"].get(creator_id, {})
 
         # Overwrite settings with clip metadata is "sourceResolution"
-        overwrite_clip_metadata = inst_data.get("sourceResolution", False)
+        creator_attributes = instance.data['creator_attributes']
+        overwrite_clip_metadata = creator_attributes.get("sourceResolution", False)
         if overwrite_clip_metadata:
             clip_metadata = inst_data["clip_source_resolution"]
             width = clip_metadata["width"]


### PR DESCRIPTION
## Changelog Description

helps resolve https://github.com/ynput/ayon-core/issues/1289

Resolve `Create Publishable Clip` creator supports a `sourceResolution` attribute, that allow the new shot to be created to pick-up its resolution from the hero plate instead of the timeline.
This attribute was only exposed as creator level and not anymore, this PR brings it as `creator_attributes` for shot instance(s).
![image](https://github.com/user-attachments/assets/e4752aa9-2162-4cd6-9946-e6fc0c0a12eb)


## Additional review information

This report this change from Hiero in Resolve:
https://github.com/ynput/ayon-hiero/pull/66

## Testing notes:
1. Ensure this attribute is properly exposed for shots, for existing and new created instances.