### PR TITLE
Make ayon-resolve support free DaVinci Resolve version.

### DIFF
--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -2,7 +2,8 @@
 resolve api
 """
 from .utils import (
-    get_resolve_module
+    get_resolve_module,
+    set_resolve_module
 )
 
 from .pipeline import (
@@ -96,6 +97,7 @@ __all__ = [
 
     # utils
     "get_resolve_module",
+    "set_resolve_module",
 
     # lib
     "maintain_current_timeline",

--- a/client/ayon_resolve/api/menu.py
+++ b/client/ayon_resolve/api/menu.py
@@ -145,7 +145,10 @@ class AYONMenu(QtWidgets.QWidget):
 
 
 def launch_ayon_menu():
-    app = QtWidgets.QApplication(sys.argv)
+    app = (
+        QtWidgets.QApplication.instance()
+        or QtWidgets.QApplication(sys.argv)
+    )
 
     ayon_menu = AYONMenu()
 

--- a/client/ayon_resolve/api/pipeline.py
+++ b/client/ayon_resolve/api/pipeline.py
@@ -32,7 +32,10 @@ from ayon_core.host import (
 
 from . import constants
 from . import lib
-from .utils import get_resolve_module
+from .utils import (
+    get_resolve_module,
+    set_resolve_module
+)
 from .workio import (
     open_file,
     save_file,
@@ -56,6 +59,7 @@ AVALON_CONTAINERS = ":AVALON_CONTAINERS"
 
 class ResolveHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "resolve"
+    _app = None
 
     def install(self):
         """Install resolve-specific functionality of avalon-core.
@@ -79,11 +83,28 @@ class ResolveHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
         register_inventory_action_path(INVENTORY_PATH)
 
+        # DaVinci Resolve version >= 20
+        # Set api resolve modules from undocumented injected cached app.
+        # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
+        try:
+            bmdvf = self._app
+            bmdvr = self._app.GetResolve()
+            assert bmdvr and bmdvf
+            set_resolve_module(bmdvr, bmdvf)
+
+        # If any issue, default to DaVinci Resolve Studio mechanism.
+        except Exception as error:
+            log.info(
+                "Could not gather resolve apps from cached entry point %r. "
+                "Default to DaVinci Resolve Studio specific logic.",
+                error,
+            )
+            get_resolve_module()
+
         # register callback for switching publishable
         pyblish.register_callback("instanceToggled",
                                   on_pyblish_instance_toggled)
 
-        get_resolve_module()
 
     def open_workfile(self, filepath):
         success = open_file(filepath)
@@ -118,6 +139,12 @@ class ResolveHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def update_context_data(self, data, changes):
         # TODO: implement to support persisting context attributes
         pass
+
+    @classmethod
+    def set_resolve_modules_from_app(cls, app):
+        """ Cache injected entry point "app" as class variable for re-use.
+        """
+        cls._app = app
 
     @staticmethod
     def _show_ayon_settings_confirmation_windows():

--- a/client/ayon_resolve/api/pipeline.py
+++ b/client/ayon_resolve/api/pipeline.py
@@ -89,7 +89,10 @@ class ResolveHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         try:
             bmdvf = self._app
             bmdvr = self._app.GetResolve()
-            assert bmdvr and bmdvf
+
+            if not bmdvr:
+                raise RuntimeError("Expecting valid Resolve module from app.")
+
             set_resolve_module(bmdvr, bmdvf)
 
         # If any issue, default to DaVinci Resolve Studio mechanism.

--- a/client/ayon_resolve/api/utils.py
+++ b/client/ayon_resolve/api/utils.py
@@ -75,8 +75,17 @@ def get_resolve_module():
     # assign global var and return
     bmdvr = bmd.scriptapp("Resolve")
     bmdvf = bmd.scriptapp("Fusion")
-    api.bmdvr = bmdvr
-    api.bmdvf = bmdvf
+    set_resolve_module(bmdvr, bmdvf)
+
+
+def set_resolve_module(resolve_app, fusion_app):
+    """ Set Fusion and Resolve app as public api modules.
+    """
+    from ayon_resolve import api
+
+    api.bmdvr = resolve_app
+    api.bmdvf = fusion_app
+
     log.info(("Assigning resolve module to "
               f"`ayon_resolve.api.bmdvr`: {api.bmdvr}"))
     log.info(("Assigning resolve module to "

--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -382,8 +382,8 @@ class LoadMedia(LoaderPlugin):
             data[key] = version["attrib"][key]
 
         # version.data
-        for key in ["author"]:
-            data[key] = version["data"][key]
+        if "author" in version["data"]:
+            data["author"] = version["data"]["author"]
 
         # add variables related to version context
         data.update({

--- a/client/ayon_resolve/startup.py
+++ b/client/ayon_resolve/startup.py
@@ -35,7 +35,7 @@ def ensure_installed_host():
     # Register injected "app" variable at class level for future uses.
     # For free version of DaVinci Resolve, this seems to be
     # the only way to gather the Resolve/Fusion applications.
-    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)
+    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
 
     host = ayon_resolve.api.ResolveHost()
     install_host(host)

--- a/client/ayon_resolve/startup.py
+++ b/client/ayon_resolve/startup.py
@@ -32,7 +32,7 @@ def ensure_installed_host():
     # the only way to gather the Resolve/Fusion applications.
     #
     # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
-    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)
+    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
 
     host = ayon_resolve.api.ResolveHost()
     install_host(host)

--- a/client/ayon_resolve/startup.py
+++ b/client/ayon_resolve/startup.py
@@ -27,6 +27,13 @@ def ensure_installed_host():
     if host:
         return host
 
+    # Register injected "app" variable at class level for future uses.
+    # For free version of DaVinci Resolve, this seems to be
+    # the only way to gather the Resolve/Fusion applications.
+    #
+    # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
+    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)
+
     host = ayon_resolve.api.ResolveHost()
     install_host(host)
     return registered_host()

--- a/client/ayon_resolve/startup.py
+++ b/client/ayon_resolve/startup.py
@@ -16,6 +16,11 @@ import ayon_resolve.api
 log = Logger.get_logger(__name__)
 
 
+# Undocumented app variable is injected by Resolve automatically
+# https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
+app: object   # noqa: F821
+
+
 def ensure_installed_host():
     """Install resolve host with openpype and return the registered host.
 
@@ -30,9 +35,7 @@ def ensure_installed_host():
     # Register injected "app" variable at class level for future uses.
     # For free version of DaVinci Resolve, this seems to be
     # the only way to gather the Resolve/Fusion applications.
-    #
-    # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
-    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
+    ayon_resolve.api.ResolveHost.set_resolve_modules_from_app(app)
 
     host = ayon_resolve.api.ResolveHost()
     install_host(host)

--- a/client/ayon_resolve/utility_scripts/AYON__Menu.py
+++ b/client/ayon_resolve/utility_scripts/AYON__Menu.py
@@ -7,15 +7,18 @@ from ayon_core.lib import Logger
 log = Logger.get_logger(__name__)
 
 
+# Undocumented app variable is injected by Resolve automatically
+# https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
+app: object   # noqa: F821
+
+
 def main(env):
     from ayon_resolve.api import ResolveHost, launch_ayon_menu
 
     # Register injected "app" variable at class level for future uses.
     # For free version of DaVinci Resolve, this seems to be
     # the only way to gather the Resolve/Fusion applications.
-    #
-    # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
-    ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
+    ResolveHost.set_resolve_modules_from_app(app)
 
     # activate resolve from openpype
     host = ResolveHost()

--- a/client/ayon_resolve/utility_scripts/AYON__Menu.py
+++ b/client/ayon_resolve/utility_scripts/AYON__Menu.py
@@ -10,6 +10,13 @@ log = Logger.get_logger(__name__)
 def main(env):
     from ayon_resolve.api import ResolveHost, launch_ayon_menu
 
+    # Register injected "app" variable at class level for future uses.
+    # For free version of DaVinci Resolve, this seems to be
+    # the only way to gather the Resolve/Fusion applications.
+    #
+    # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
+    ResolveHost.set_resolve_modules_from_app(app)
+
     # activate resolve from openpype
     host = ResolveHost()
     install_host(host)

--- a/client/ayon_resolve/utility_scripts/AYON__Menu.py
+++ b/client/ayon_resolve/utility_scripts/AYON__Menu.py
@@ -9,7 +9,7 @@ log = Logger.get_logger(__name__)
 
 # Undocumented app variable is injected by Resolve automatically
 # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
-app: object   # noqa: F821
+app: object  # noqa: F821
 
 
 def main(env):
@@ -18,7 +18,7 @@ def main(env):
     # Register injected "app" variable at class level for future uses.
     # For free version of DaVinci Resolve, this seems to be
     # the only way to gather the Resolve/Fusion applications.
-    ResolveHost.set_resolve_modules_from_app(app)
+    ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
 
     # activate resolve from openpype
     host = ResolveHost()

--- a/client/ayon_resolve/utility_scripts/AYON__Menu.py
+++ b/client/ayon_resolve/utility_scripts/AYON__Menu.py
@@ -15,7 +15,7 @@ def main(env):
     # the only way to gather the Resolve/Fusion applications.
     #
     # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252
-    ResolveHost.set_resolve_modules_from_app(app)
+    ResolveHost.set_resolve_modules_from_app(app)  # noqa: F821
 
     # activate resolve from openpype
     host = ResolveHost()


### PR DESCRIPTION
## Changelog Description

Rework the Fusion+Resolve application gathering so it can accomodate the free version of DaVinci Resolve. 
Based on: https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=113252

## Testing notes:
1. Tested on DaVinci Resolve 20 and DaVinci Resolve Studio 20
2. Ensure all apps are loaded as expcted
3. Publish editorial data from free version
