### PR TITLE
load audio product types

### DIFF
--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -137,11 +137,11 @@ def find_clip_usage(media_pool_item, project=None):
 class LoadMedia(LoaderPlugin):
     """Load product as media pool item."""
 
-    product_types = {"render2d", "source", "plate", "render", "review"}
+    product_types = {"render2d", "source", "plate", "render", "review", "audio"}
 
     representations = ["*"]
     extensions = set(
-        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS)
+        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS, {".wav"})
     )
 
     label = "Load media"


### PR DESCRIPTION
## Changelog Description
This adds support for loading and managing audio products via AYON Loader.

## Additional review information
This is rather a patch for `load_media` as it handles audio just as good as imagery.

We might think about deprecating `load_clip` as it's currently throwing errors and all of my editors are always using `load_media` over it. Thie difference is that `load_clip` places metadata on the TimelineItem whereas `load_media` places them on the MediaSource and I'm not quite sure in which scenarios the former would be desireable

## Testing notes:
1. ensure an `audio` product is published to your project
2. open Resolve
3. locate and load the `audio` product via AYON Loader
4. play around with the Scene Inventory features
