### PR TITLE
Close AYON Menus when Resolve is shutdown

### DIFF
--- a/client/ayon_resolve/api/menu.py
+++ b/client/ayon_resolve/api/menu.py
@@ -8,6 +8,8 @@ from ayon_core.pipeline import registered_host
 from ayon_core.style import load_stylesheet
 from ayon_core.resources import get_ayon_icon_filepath
 
+from .pulse import ResolvePulse
+
 MENU_LABEL = os.environ["AYON_MENU_LABEL"]
 
 
@@ -96,6 +98,10 @@ class AYONMenu(QtWidgets.QWidget):
 
         # Resize width, make height as small fitting as possible
         self.resize(200, 1)
+
+        # Force close current process if Resolve is closed
+        self._pulse = ResolvePulse(parent=self)
+        self._pulse.start()
 
     def on_save_current_clicked(self):
         host = registered_host()

--- a/client/ayon_resolve/api/pulse.py
+++ b/client/ayon_resolve/api/pulse.py
@@ -1,0 +1,65 @@
+"""This module is a copy from ayon-resolve"""
+
+import os
+import sys
+
+from qtpy import QtCore
+
+
+class PulseThread(QtCore.QThread):
+    no_response = QtCore.Signal()
+
+    def __init__(self, parent=None):
+        super(PulseThread, self).__init__(parent=parent)
+
+    def run(self):
+        app = getattr(sys.modules["__main__"], "app", None)
+
+        # Interval in milliseconds
+        interval = os.environ.get("AYON_RESOLVE_PULSE_INTERVAL", 1000)
+
+        while True:
+            if self.isInterruptionRequested():
+                return
+
+            # We don't need to call Test because PyRemoteObject of the app
+            # will actually fail to even resolve the Test function if it has
+            # gone down. So we can actually already just check by confirming
+            # the method is still getting resolved. (Optimization)
+            if app.Test is None:
+                self.no_response.emit()
+
+            self.msleep(interval)
+
+
+class ResolvePulse(QtCore.QObject):
+    """A Timer that checks whether host app is still alive.
+
+    This checks whether the Resolve process is still active at a certain
+    interval. This is useful due to how Resolve runs its scripts. Each script
+    runs in its own environment and process (a `fusionscript` process each).
+    If Resolve would go down and we have a UI process running at the same time
+    then it can happen that the `fusionscript.exe` will remain running in the
+    background in limbo due to e.g. a Qt interface's QApplication that keeps
+    running infinitely.
+
+    Warning:
+        When the host is not detected this will automatically exit
+        the current process.
+
+    """
+
+    def __init__(self, parent=None):
+        super(ResolvePulse, self).__init__(parent=parent)
+        self._thread = PulseThread(parent=self)
+        self._thread.no_response.connect(self.on_no_response)
+
+    def on_no_response(self):
+        print("Pulse detected no response from Fusion..")
+        sys.exit(1)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._thread.requestInterruption()


### PR DESCRIPTION
## Changelog Description
Adds a pulse timer to poll whether Resolve is running or not and shuts down the AYON Menu UI process when Resolve is closed.

## Additional review information
This is basically a copy from ayon-resolve.
- https://github.com/ynput/ayon-fusion/blob/4bfaf0a943cb4aca178a42aa06e2ec51a63ff82d/client/ayon_fusion/api/pulse.py
- https://github.com/ynput/ayon-fusion/blob/f2b1d0683de4b7f8901185f45089d60ef0126db2/client/ayon_fusion/api/menu.py#L122-L126

## Testing notes:
1. start Resolve via AYON Launcher
2. open up as many AYON menus as u like
3. close down Resolve normally
4. wait for the AYON menus being closed (shouldn't take more than 5 seconds)
