### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -49,16 +49,18 @@ class CreateWorkfile(AutoCreator):
         variant = self.default_variant
         project_name = self.create_context.get_current_project_name()
         host_name = self.create_context.host_name
+        project_entity = self.create_context.get_current_project_entity()
         folder_entity = self.create_context.get_current_folder_entity()
         task_entity = self.create_context.get_current_task_entity()
         folder_path = folder_entity["path"]
         task_name = task_entity["name"]
         product_name = self.get_product_name(
-            project_name,
-            folder_entity,
-            task_entity,
-            self.default_variant,
-            host_name,
+            project_name=project_name,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            variant=self.default_variant,
+            host_name=host_name,
         )
         data = {
             "folderPath": folder_path,


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
