### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -24,6 +24,7 @@ class CreateEditorialPackage(ResolveCreator):
     identifier = "io.ayon.creators.resolve.editorial_pkg"
     label = "Editorial Package"
     product_type = "editorial_pkg"
+    product_base_type = "editorial_pkg"
     icon = "camera"
     defaults = ["Main"]
 

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -165,7 +165,8 @@ class _ResolveInstanceClipCreator(plugin.HiddenResolvePublishCreator):
 class ResolveShotInstanceCreator(_ResolveInstanceClipCreator):
     """Shot product type creator class"""
     identifier = "io.ayon.creators.resolve.shot"
-    product_type = "shot"    
+    product_type = "shot"
+    product_base_type = "shot"
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -226,7 +227,7 @@ class _ResolveInstanceClipCreatorBase(_ResolveInstanceClipCreator):
             )
         ]
 
-        if self.product_type in ("plate", "audio"):
+        if self.product_base_type in ("plate", "audio"):
             instance_attributes.append(
                 BoolDef(
                     "review",
@@ -236,7 +237,7 @@ class _ResolveInstanceClipCreatorBase(_ResolveInstanceClipCreator):
                 )
             )
 
-        if self.product_type == "plate":
+        if self.product_base_type == "plate":
             current_review = instance.creator_attributes.get("review", False)
             instance_attributes.append(
                 EnumDef(
@@ -263,6 +264,7 @@ class EditorialPlateInstanceCreator(_ResolveInstanceClipCreatorBase):
     """Plate product type creator class"""
     identifier = "io.ayon.creators.resolve.plate"
     product_type = "plate"
+    product_base_type = "plate"
     label = "Editorial Plate"
 
 
@@ -270,6 +272,7 @@ class EditorialAudioInstanceCreator(_ResolveInstanceClipCreatorBase):
     """Audio product type creator class"""
     identifier = "io.ayon.creators.resolve.audio"
     product_type = "audio"
+    product_base_type = "audio"
     label = "Editorial Audio"
 
 
@@ -279,6 +282,7 @@ class CreateShotClip(plugin.ResolveCreator):
     identifier = "io.ayon.creators.resolve.clip"
     label = "Create Publishable Clip"
     product_type = "editorial"
+    product_base_type = "editorial"
     icon = "film"
     defaults = ["Main"]
 
@@ -629,6 +633,7 @@ OTIO file.
                         {
                             "variant": "main",
                             "productType": "shot",
+                            "productBaseType": "shot",
                             "productName": "shotMain",
                             "label": f"{shot_folder_path} shotMain",
                         }
@@ -673,6 +678,7 @@ OTIO file.
                 elif creator_id == audio_creator_id:
                     sub_instance_data["variant"] = "main"
                     sub_instance_data["productType"] = "audio"
+                    sub_instance_data["productBaseType"] = "audio"
                     sub_instance_data["productName"] = "audioMain"
 
                     parenting_data = shot_instances[shot_creator_id]

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -17,6 +17,7 @@ class CreateWorkfile(AutoCreator):
     identifier = "io.ayon.creators.resolve.workfile"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
 
     default_variant = "Main"
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.