### PR TITLE
Fix Resolve version comparison

### DIFF
--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -1205,7 +1205,7 @@ def export_timeline_otio_native(timeline, filepath):
         # Native otio export is available from Resolve 18.5
         # [major, minor, patch, build, suffix]
         resolve_version = bmdvr.GetVersion()
-        if resolve_version < (18, 5):
+        if tuple(resolve_version[:2]) < (18, 5):
             # if it is lower then use ayon's otio exporter
             otio_timeline = davinci_export.create_otio_timeline(
                 resolve_project, timeline=timeline)

--- a/client/ayon_resolve/plugins/publish/extract_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/extract_editorial_package.py
@@ -153,7 +153,7 @@ class ExtractEditorialPackage(publish.Extractor):
         # Native otio export is available from Resolve 18.5
         # [major, minor, patch, build, suffix]
         resolve_version = bmdvr.GetVersion()
-        if resolve_version < (18, 5):
+        if tuple(resolve_version[:2]) < (18, 5):
             # if it is lower then use ayon's otio exporter
             otio_timeline = davinci_export.create_otio_timeline(
                 resolve_project, timeline=timeline


### PR DESCRIPTION
## Changelog Description

Fix Resolve version comparison

## Additional review information

Avoid error:
```
Traceback (most recent call last):
  File "\ayon_2510271030_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "\resolve_0.5.6\ayon_resolve\plugins\publish\extract_editorial_package.py", line 63, in process
    self.export_otio_representation(
  File "\resolve_0.5.6\ayon_resolve\plugins\publish\extract_editorial_package.py", line 156, in export_otio_representation
    if resolve_version < (18, 5):
TypeError: '<' not supported between instances of 'list' and 'tuple'
```

Fix: https://github.com/ynput/ayon-resolve/issues/82

## Testing notes:

1. Test whether this works please.