### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -59,9 +59,7 @@ from .plugin import (
     ClipLoader,
     TimelineItemLoader,
     ResolveCreator,
-    Creator,  # backward compatibility
     PublishableClip,
-    PublishClip,  # backward compatibility
 )
 
 from .workio import (
@@ -144,9 +142,7 @@ __all__ = [
     "ClipLoader",
     "TimelineItemLoader",
     "ResolveCreator",
-    "Creator",  # backward compatibility
     "PublishableClip",
-    "PublishClip",  # backward compatibility
 
     # workio
     "open_file",

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -626,7 +626,7 @@ set_timeline_item_pype_tag = set_timeline_item_ayon_tag
 
 def imprint(timeline_item, data=None):
     """
-    Adding `Ayon data` into a timeline item track item tag.
+    Adding `AYON data` into a timeline item track item tag.
 
     Also including publish attribute into tag.
 
@@ -636,9 +636,9 @@ def imprint(timeline_item, data=None):
 
     Examples:
         data = {
-            'asset': 'sq020sh0280',
-            'family': 'render',
-            'subset': 'subsetMain'
+            'folderPath': '/shots/sq020sh0280',
+            'productBaseType': 'render',
+            'productName': 'renderMain'
         }
     """
     data = data or {}

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -298,7 +298,7 @@ class ResolveCreator(Creator):
 
     def apply_settings(self, project_settings):
         resolve_create_settings = (
-            project_settings.get("resolve", {}).get("create")
+            project_settings[self.settings_category]["create"]
         )
         self.presets = resolve_create_settings.get(
             self.__class__.__name__, {}

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -304,7 +304,7 @@ class ResolveCreator(Creator):
             self.__class__.__name__, {}
         )
 
-    def create(self, subset_name, instance_data, pre_create_data):
+    def create(self, product_name, instance_data, pre_create_data):
         # adding basic current context resolve objects
         self.project = lib.get_current_resolve_project()
         self.timeline = lib.get_current_timeline()
@@ -510,12 +510,12 @@ class PublishableClip:
             for key in ["folder", "episode", "sequence", "track", "shot"]
         }
 
-        # build subset name from layer name
+        # build product name from layer name
         if self.variant == "<track_name>":
             self.variant = self.track_name
 
-        # create subset for publishing
-        # TODO: Use creator `get_subset_name` to correctly define name
+        # create product name for publishing
+        # TODO: Use creator `get_product_name` to correctly define name
         self.product_name = self.product_base_type + self.variant.capitalize()
 
     def _replace_hash_to_expression(self, name, text):

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -312,10 +312,6 @@ class ResolveCreator(Creator):
             self.selected = lib.get_current_timeline_items(filter=False)
 
 
-# alias for backward compatibility
-Creator = ResolveCreator  # noqa
-
-
 class PublishableClip:
     """
     Convert a track item to publishable instance
@@ -729,9 +725,6 @@ class PublishableClip:
         for key in par_split:
             parent = self._convert_to_entity(key)
             self.parents.append(parent)
-
-# alias for backward compatibility
-PublishClip = PublishableClip  # noqa
 
 
 class HiddenResolvePublishCreator(HiddenCreator):

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -294,15 +294,6 @@ class ResolveCreator(Creator):
     settings_category = "resolve"
     host_name = "resolve"
     marker_color = "Purple"
-    presets = {}
-
-    def apply_settings(self, project_settings):
-        resolve_create_settings = (
-            project_settings[self.settings_category]["create"]
-        )
-        self.presets = resolve_create_settings.get(
-            self.__class__.__name__, {}
-        )
 
     def create(self, product_name, instance_data, pre_create_data):
         # adding basic current context resolve objects

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -290,6 +290,9 @@ class TimelineItemLoader(LoaderPlugin):
 class ResolveCreator(Creator):
     """ Resolve Creator class wrapper"""
 
+    skip_discovery = True
+    settings_category = "resolve"
+    host_name = "resolve"
     marker_color = "Purple"
     presets = {}
 
@@ -728,6 +731,7 @@ class PublishableClip:
 
 
 class HiddenResolvePublishCreator(HiddenCreator):
+    skip_discovery = True
     host_name = "resolve"
     settings_category = "resolve"
 
@@ -742,9 +746,8 @@ class HiddenResolvePublishCreator(HiddenCreator):
 
 
 class ResolvePublishCreator(ResolveCreator):
+    skip_discovery = True
     create_allow_context_change = True
-    host_name = "resolve"
-    settings_category = "resolve"
 
     def collect_instances(self):
         pass

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -748,7 +748,7 @@ class HiddenResolvePublishCreator(HiddenCreator):
         pass
 
 
-class ResolvePublishCreator(Creator):
+class ResolvePublishCreator(ResolveCreator):
     create_allow_context_change = True
     host_name = "resolve"
     settings_category = "resolve"

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -516,7 +516,7 @@ class PublishableClip:
 
         # create subset for publishing
         # TODO: Use creator `get_subset_name` to correctly define name
-        self.product_name = self.product_type + self.variant.capitalize()
+        self.product_name = self.product_base_type + self.variant.capitalize()
 
     def _replace_hash_to_expression(self, name, text):
         """ Replace hash with number in correct padding. """

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -547,7 +547,6 @@ class PublishableClip:
         self.count_steps *= self.rename_index
 
         hierarchy_formatting_data = {}
-        _data = self.timeline_item_default_data.copy()
         if self.pre_create_data:
 
             # adding tag metadata from ui
@@ -574,9 +573,6 @@ class PublishableClip:
                     self.shot_num = self.count_from
                 else:
                     self.shot_num = self.count_from + self.count_steps
-
-            # clip name sequence number
-            _data.update({"shot": self.shot_num})
 
             # solve # in test to pythonic expression
             for _key, _value in self.hierarchy_data.items():

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -479,27 +479,28 @@ class PublishableClip:
         self.shot_num = self.ti_index
 
         # publisher ui attribute inputs or default values if gui was not used
-        def get(key):
+        def get(key, default):
             """Shorthand access for code readability"""
-            return self.pre_create_data.get(key)
+            return self.pre_create_data.get(key) or default
 
-        self.rename = get("clipRename") or self.rename_default
-        self.clip_name = get("clipName") or self.clip_name_default
-        self.hierarchy = get("hierarchy") or self.hierarchy_default
-        self.count_from = get("countFrom") or self.count_from_default
-        self.count_steps = get("countSteps") or self.count_steps_default
-        self.variant = get("clip_variant") or self.variant_default
-        self.plate_product_type = (
-            get("plate_product_type") or self.plate_product_type_default
+        self.rename = get("clipRename", self.rename_default)
+        self.clip_name = get("clipName", self.clip_name_default)
+        self.hierarchy = get("hierarchy", self.hierarchy_default)
+        self.count_from = get("countFrom", self.count_from_default)
+        self.count_steps = get("countSteps", self.count_steps_default)
+        self.variant = get("clip_variant", self.variant_default)
+        self.plate_product_type = get(
+            "plate_product_type", self.plate_product_type_default
         )
-        self.vertical_sync = get("vSyncOn") or self.vertical_sync_default
-        self.hero_track = get("vSyncTrack") or self.driving_layer_default
+        self.vertical_sync = get("vSyncOn", self.vertical_sync_default)
+        self.hero_track = get("vSyncTrack", self.driving_layer_default)
         self.hero_track = self.hero_track.replace(" ", "_")
-        self.review_source = (
-            get("reviewableSource") or self.review_source_default)
+        self.review_source = get(
+            "reviewableSource", self.review_source_default
+        )
 
         self.hierarchy_data = {
-            key: get(key) or self.timeline_item_default_data[key]
+            key: get(key, self.timeline_item_default_data[key])
             for key in ["folder", "episode", "sequence", "track", "shot"]
         }
 

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -335,7 +335,7 @@ class PublishableClip:
     clip_name_default = "shot_{_trackIndex_:0>3}_{_clipIndex_:0>4}"
     variant_default = "<track_name>"
     review_source_default = None
-    product_type_default = "plate"
+    plate_product_type_default = "plate"
     count_from_default = 10
     count_steps_default = 10
     vertical_sync_default = False
@@ -489,7 +489,9 @@ class PublishableClip:
         self.count_from = get("countFrom") or self.count_from_default
         self.count_steps = get("countSteps") or self.count_steps_default
         self.variant = get("clip_variant") or self.variant_default
-        self.product_type = get("productType") or self.product_type_default
+        self.plate_product_type = (
+            get("plate_product_type") or self.plate_product_type_default
+        )
         self.vertical_sync = get("vSyncOn") or self.vertical_sync_default
         self.hero_track = get("vSyncTrack") or self.driving_layer_default
         self.hero_track = self.hero_track.replace(" ", "_")
@@ -689,7 +691,7 @@ class PublishableClip:
             "parents": self.parents,
             "hierarchyData": hierarchy_formatting_data,
             "productName": self.product_name,
-            "productType": self.product_type
+            "productType": self.plate_product_type
         }
 
     def _convert_to_entity(self, key):

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -373,7 +373,7 @@ class PublishableClip:
             data (dict): additional data
 
         """
-        self.vertical_clip_match = vertical_clip_match 
+        self.vertical_clip_match = vertical_clip_match
         self.vertical_clip_used = vertical_clip_used
 
         self.rename_index = rename_index
@@ -500,7 +500,7 @@ class PublishableClip:
         )
 
         self.hierarchy_data = {
-            key: get(key, self.timeline_item_default_data[key])
+            key: get(key, self.timeline_item_default_data.get(f"_{key}_", ""))
             for key in ["folder", "episode", "sequence", "track", "shot"]
         }
 
@@ -510,7 +510,7 @@ class PublishableClip:
 
         # create product name for publishing
         # TODO: Use creator `get_product_name` to correctly define name
-        self.product_name = self.product_base_type + self.variant.capitalize()
+        self.product_name = self.plate_product_type + self.variant.capitalize()
 
     def _replace_hash_to_expression(self, name, text):
         """ Replace hash with number in correct padding. """

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -502,14 +502,8 @@ class PublishableClip:
         )
 
         self.hierarchy_data = {
-            key: get(key, self.timeline_item_default_data[default_key])
-            for key, default_key in [
-                ("folder", "_folder_"),
-                ("episode", "_epidose_"),
-                ("sequence", "_sequence_"),
-                ("track", "_track_"),
-                ("shot", "_shot_"),
-            ]
+            key: get(key, self.timeline_item_default_data[f"_{key}_"])
+            for key in ["folder", "episode", "sequence", "track", "shot"]
         }
 
         # build product name from layer name

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -462,11 +462,13 @@ class PublishableClip:
 
         self.timeline_item_default_data = {
             "_folder_": "shots",
+            "_episode_": "sq01",
             "_sequence_": self.timeline_name,
+            "_shot_": "sh###",
             "_track_": self.track_name,
             "_clip_": self.ti_name,
             "_trackIndex_": self.track_index,
-            "_clipIndex_": self.ti_index
+            "_clipIndex_": self.ti_index,
         }
 
     def _populate_attributes(self):
@@ -500,8 +502,14 @@ class PublishableClip:
         )
 
         self.hierarchy_data = {
-            key: get(key, self.timeline_item_default_data.get(f"_{key}_", ""))
-            for key in ["folder", "episode", "sequence", "track", "shot"]
+            key: get(key, self.timeline_item_default_data[default_key])
+            for key, default_key in [
+                ("folder", "_folder_"),
+                ("episode", "_epidose_"),
+                ("sequence", "_sequence_"),
+                ("track", "_track_"),
+                ("shot", "_shot_"),
+            ]
         }
 
         # build product name from layer name

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -541,6 +541,7 @@ class PublishableClip:
         self.count_steps *= self.rename_index
 
         hierarchy_formatting_data = {}
+        _data = self.timeline_item_default_data.copy()
         if self.pre_create_data:
 
             # adding tag metadata from ui
@@ -567,6 +568,9 @@ class PublishableClip:
                     self.shot_num = self.count_from
                 else:
                     self.shot_num = self.count_from + self.count_steps
+
+            # clip name sequence number
+            _data.update({"shot": self.shot_num})
 
             # solve # in test to pythonic expression
             for _key, _value in self.hierarchy_data.items():

--- a/client/ayon_resolve/plugins/create/create_editorial_package.py
+++ b/client/ayon_resolve/plugins/create/create_editorial_package.py
@@ -23,8 +23,8 @@ class CreateEditorialPackage(ResolveCreator):
 
     identifier = "io.ayon.creators.resolve.editorial_pkg"
     label = "Editorial Package"
-    product_type = "editorial_pkg"
     product_base_type = "editorial_pkg"
+    product_type = product_base_type
     icon = "camera"
     defaults = ["Main"]
 
@@ -58,9 +58,11 @@ class CreateEditorialPackage(ResolveCreator):
             instance_data (dict): The instance data.
             pre_create_data (dict): The pre_create context data.
         """
-        super().create(product_name,
-                       instance_data,
-                       pre_create_data)
+        super().create(
+            product_name,
+            instance_data,
+            pre_create_data
+        )
 
         current_timeline = lib.get_current_timeline()
 
@@ -89,12 +91,16 @@ class CreateEditorialPackage(ResolveCreator):
         timeline_media_pool_item.SetMetadata(
             constants.AYON_TAG_NAME, json.dumps(tag_metadata)
         )
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
 
         new_instance = CreatedInstance(
-            self.product_type,
-            product_name,
-            tag_metadata["publish"],
-            self,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=tag_metadata["publish"],
+            creator=self,
         )
         new_instance.transient_data["timeline_pool_item"] = (
             timeline_media_pool_item)
@@ -116,13 +122,23 @@ class CreateEditorialPackage(ResolveCreator):
                 )
                 continue
 
-            # exclude all which are not productType editorial_pkg
-            if (
-                data.get("publish", {}).get("productType") != self.product_type
-            ):
+            publish_data = data.get("publish")
+            if not publish_data:
                 continue
 
-            publish_data = data["publish"]
+            product_type = publish_data.get("productType")
+            product_base_type = publish_data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = product_type
+
+            # exclude all which are not productType editorial_pkg
+            if product_base_type != self.product_base_type:
+                continue
+
+            if not product_type:
+                product_type = self.product_base_type
+
+            product_name = publish_data["productName"]
 
             # add label into instance data in case it is missing in publish
             # data (legacy publish) or timeline was renamed.
@@ -132,15 +148,14 @@ class CreateEditorialPackage(ResolveCreator):
             # add variant into instance data in case it is missing in publish
             # data
             if "variant" not in publish_data:
-                product_name = publish_data["productName"]
-                product_type = publish_data["productType"]
                 publish_data["variant"] = product_name.split(product_type)[1]
 
             current_instance = CreatedInstance(
-                self.product_type,
-                publish_data["productName"],
-                publish_data,
-                self
+                product_base_type=self.product_base_type,
+                product_type=product_type,
+                product_name=product_name,
+                data=publish_data,
+                creator=self,
             )
 
             current_instance.transient_data["timeline_pool_item"] = (

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -467,7 +467,7 @@ OTIO file.
             BoolDef(
                 "export_audio",
                 label="Include audio",
-                tooltip="Process subsets with corresponding audio",
+                tooltip="Process products with corresponding audio",
                 default=False,
             ),
             BoolDef(
@@ -501,9 +501,9 @@ OTIO file.
             ),
         ]
 
-    def create(self, subset_name, instance_data, pre_create_data):
-        super(CreateShotClip, self).create(
-            subset_name,
+    def create(self, product_name, instance_data, pre_create_data):
+        super().create(
+            product_name,
             instance_data,
             pre_create_data
         )

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -630,12 +630,13 @@ OTIO file.
                 pre_create_data.get("export_audio", False)
             )
 
-            enabled_creators = tuple(cre for cre, enabled in all_creators.items() if enabled)
             shot_folder_path = segment_data["folderPath"]
             shot_instances = all_shot_instances.setdefault(
                 shot_folder_path, {})
 
-            for creator_id in enabled_creators:
+            for creator_id, enabled in all_creators.items():
+                if not enabled:
+                    continue
                 creator = self.create_context.creators[creator_id]
                 sub_instance_data = copy.deepcopy(segment_data)
                 shot_folder_path = sub_instance_data["folderPath"]

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -311,6 +311,16 @@ OTIO file.
 """
     create_allow_thumbnail = False
 
+    presets = {}
+
+    def apply_settings(self, project_settings):
+        self.presets = (
+            project_settings
+            [self.settings_category]
+            ["create"]
+            [self.__class__.__name__]
+        )
+
     def get_pre_create_attr_defs(self):
 
         def header_label(text):

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -551,9 +551,9 @@ OTIO file.
         media_pool_folder = create_bin(self.timeline.GetName())
 
         # detect enabled creators for review, plate and audio
-        shot_creator_id = "io.ayon.creators.resolve.shot"
-        plate_creator_id = "io.ayon.creators.resolve.plate"
-        audio_creator_id = "io.ayon.creators.resolve.audio"
+        shot_creator_id = ResolveShotInstanceCreator.identifier
+        plate_creator_id = EditorialPlateInstanceCreator.identifier
+        audio_creator_id = EditorialAudioInstanceCreator.identifier
         all_creators = {
             shot_creator_id: True,
             plate_creator_id: True,
@@ -746,10 +746,11 @@ OTIO file.
 
         Returns:
             CreatedInstance: The newly created instance.
+
         """
         creator = self.create_context.creators[creator_id]
 
-        if creator_id == "io.ayon.creators.resolve.shot":
+        if creator_id == ResolveShotInstanceCreator.identifier:
             track_item_duration = timeline_item.GetDuration()
             workfileFrameStart = data["workfileFrameStart"]
             creator_attributes = {
@@ -791,14 +792,14 @@ OTIO file.
         })
 
         # create parent shot
-        creator_id = "io.ayon.creators.resolve.shot"
+        creator_id = ResolveShotInstanceCreator.identifier
         shot_data = tag_data.copy()
         inst = self._create_and_add_instance(
             shot_data, creator_id, timeline_item, instances)
         clip_instances[creator_id] = inst.data_to_store()
 
         # create children plate
-        creator_id = "io.ayon.creators.resolve.plate"
+        creator_id = EditorialPlateInstanceCreator.identifier
         plate_data = tag_data.copy()
         plate_data.update({
             "parent_instance_id": inst["instance_id"],

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -92,6 +92,7 @@ CLIP_ATTR_DEFS = [
 class _ResolveInstanceClipCreator(plugin.HiddenResolvePublishCreator):
     """Wrapper class for clip types products.
     """
+    skip_discovery = True
 
     def create(self, instance_data, _):
         """Return a new CreateInstance for new shot from Resolve.
@@ -185,6 +186,7 @@ class ResolveShotInstanceCreator(_ResolveInstanceClipCreator):
 class _ResolveInstanceClipCreatorBase(_ResolveInstanceClipCreator):
     """ Base clip product creator.
     """
+    skip_discovery = True
 
     def register_callbacks(self):
         self.create_context.add_value_changed_callback(self._on_value_change)

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -1,6 +1,11 @@
 import copy
 
-from ayon_resolve.api import plugin, lib, constants
+from ayon_resolve.api import lib, constants
+from ayon_resolve.api.plugin import (
+    HiddenResolvePublishCreator,
+    ResolveCreator,
+    PublishableClip,
+)
 from ayon_resolve.api.lib import (
     get_video_track_names,
     get_current_timeline_items,
@@ -89,7 +94,7 @@ CLIP_ATTR_DEFS = [
 ]
 
 
-class _ResolveInstanceClipCreator(plugin.HiddenResolvePublishCreator):
+class _ResolveInstanceClipCreator(HiddenResolvePublishCreator):
     """Wrapper class for clip types products.
     """
     skip_discovery = True
@@ -278,7 +283,7 @@ class EditorialAudioInstanceCreator(_ResolveInstanceClipCreatorBase):
     label = "Editorial Audio"
 
 
-class CreateShotClip(plugin.ResolveCreator):
+class CreateShotClip(ResolveCreator):
     """Publishable clip"""
 
     identifier = "io.ayon.creators.resolve.clip"
@@ -568,7 +573,7 @@ OTIO file.
             })
 
             # convert track item to timeline media pool item
-            publish_clip = plugin.PublishableClip(
+            publish_clip = PublishableClip(
                 track_item_data,
                 vertical_clip_match,
                 vertical_clip_used,

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -335,7 +335,7 @@ OTIO file.
             for tr_name in get_video_track_names()
         ]
 
-        return [
+        output = [
             BoolDef(
                 "use_selection",
                 label="Use only clips with <b>Chocolate</b>  clip color",
@@ -503,6 +503,25 @@ OTIO file.
             ),
         ]
 
+        for base_type, type_label, def_key in (
+            ("plate", "Plate", "plate_product_type"),
+            ("audio", "Audio", "audio_product_type"),
+        ):
+            presets_key = f"{def_key}s"
+            product_types = self.presets[presets_key]
+            if product_types:
+                output.append(
+                    EnumDef(
+                        def_key,
+                        label=f"{type_label} Product Type",
+                        tooltip=f"Select product type for {base_type}",
+                        items=product_types,
+                        default=product_types[0],
+                    )
+                )
+
+        return output
+
     def create(self, product_name, instance_data, pre_create_data):
         super().create(
             product_name,
@@ -570,6 +589,14 @@ OTIO file.
         vertical_clip_match = {}
         vertical_clip_used = {}
 
+        plate_product_type = (
+            pre_create_data.get("plate_product_type")
+            or EditorialPlateInstanceCreator.product_base_type
+        )
+        audio_product_type = (
+            pre_create_data.get("audio_product_type")
+            or EditorialAudioInstanceCreator.product_base_type
+        )
         for index, track_item_data in enumerate(sorted_selected_track_items):
 
             # Compute and store resolution metadata from mediapool clip.
@@ -684,7 +711,7 @@ OTIO file.
                             f"{sub_instance_data['productName']}"
                         )
                     })
-                    sub_instance_data["productType"] = "plate"
+                    sub_instance_data["productType"] = plate_product_type
                     sub_instance_data["productBaseType"] = "plate"
                     creator_attributes["parentInstance"] = parenting_data[
                         "label"]
@@ -697,7 +724,7 @@ OTIO file.
 
                 elif creator_id == audio_creator_id:
                     sub_instance_data["variant"] = "main"
-                    sub_instance_data["productType"] = "audio"
+                    sub_instance_data["productType"] = audio_product_type
                     sub_instance_data["productBaseType"] = "audio"
                     sub_instance_data["productName"] = "audioMain"
 

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 from ayon_resolve.api import lib, constants
@@ -12,8 +14,14 @@ from ayon_resolve.api.lib import (
     create_bin,
 )
 from ayon_core.pipeline.create import CreatorError, CreatedInstance
-from ayon_core.lib import BoolDef, EnumDef, TextDef, UILabelDef, NumberDef
-
+from ayon_core.lib import (
+    BoolDef,
+    EnumDef,
+    TextDef,
+    UILabelDef,
+    NumberDef,
+    AbstractAttrDef
+)
 
 # Used as a key by the creators in order to
 # retrieve the instances data into clip markers.
@@ -21,7 +29,7 @@ _CONTENT_ID = "resolve_sub_products"
 
 
 # Shot attributes
-CLIP_ATTR_DEFS = [
+CLIP_ATTR_DEFS: list[AbstractAttrDef] = [
     EnumDef(
         "fps",
         items=[
@@ -226,7 +234,7 @@ class _ResolveInstanceClipCreatorBase(_ResolveInstanceClipCreator):
             for tr_name in get_video_track_names()
         ]
 
-        instance_attributes = [
+        instance_attributes: list[AbstractAttrDef] = [
             TextDef(
                 "parentInstance",
                 label="Linked to",

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -335,12 +335,7 @@ OTIO file.
             for tr_name in get_video_track_names()
         ]
 
-        # Project settings might be applied to this creator via
-        # the inherited `Creator.apply_settings`
-        presets = self.presets
-
         return [
-
             BoolDef(
                 "use_selection",
                 label="Use only clips with <b>Chocolate</b>  clip color",
@@ -363,32 +358,32 @@ OTIO file.
                 label="{folder}",
                 tooltip="Name of folder used for root of generated shots.\n"
                         f"{tokens_help}",
-                default=presets.get("folder", "shots"),
+                default=self.presets["folder"],
             ),
             TextDef(
                 "episode",
                 label="{episode}",
                 tooltip=f"Name of episode.\n{tokens_help}",
-                default=presets.get("episode", "ep01"),
+                default=self.presets["episode"],
             ),
             TextDef(
                 "sequence",
                 label="{sequence}",
                 tooltip=f"Name of sequence of shots.\n{tokens_help}",
-                default=presets.get("sequence", "sq01"),
+                default=self.presets["sequence"],
             ),
             TextDef(
                 "track",
                 label="{track}",
                 tooltip=f"Name of timeline track.\n{tokens_help}",
-                default=presets.get("track", "{_track_}"),
+                default=self.presets["track"],
             ),
             TextDef(
                 "shot",
                 label="{shot}",
                 tooltip="Name of shot. '#' is converted to padded number."
                         f"\n{tokens_help}",
-                default=presets.get("shot", "sh###"),
+                default=self.presets["shot"],
             ),
 
             # renameHierarchy
@@ -400,32 +395,32 @@ OTIO file.
                 label="Shot Parent Hierarchy",
                 tooltip="Parents folder for shot root folder, "
                         "Template filled with *Hierarchy Data* section",
-                default=presets.get("hierarchy", "{folder}/{sequence}"),
+                default=self.presets["hierarchy"],
             ),
             BoolDef(
                 "clipRename",
                 label="Rename Shots/Clips",
                 tooltip="Renaming selected clips on fly",
-                default=presets.get("clipRename", False),
+                default=self.presets["clipRename"],
             ),
             TextDef(
                 "clipName",
                 label="Rename Template",
                 tooltip="template for creating shot names, used for "
                         "renaming (use rename: on)",
-                default=presets.get("clipName", "{sequence}{shot}"),
+                default=self.presets["clipName"],
             ),
             NumberDef(
                 "countFrom",
                 label="Count Sequence from",
                 tooltip="Set where the sequence number starts from",
-                default=presets.get("countFrom", 10),
+                default=self.presets["countFrom"],
             ),
             NumberDef(
                 "countSteps",
                 label="Stepping Number",
                 tooltip="What number is adding every new step",
-                default=presets.get("countSteps", 10),
+                default=self.presets["countSteps"],
             ),
 
             # verticalSync
@@ -437,7 +432,7 @@ OTIO file.
                 label="Enable Vertical Sync",
                 tooltip="Switch on if you want clips above "
                         "each other to share its attributes",
-                default=presets.get("vSyncOn", True),
+                default=self.presets["vSyncOn"],
             ),
             EnumDef(
                 "vSyncTrack",
@@ -492,19 +487,19 @@ OTIO file.
                 "workfileFrameStart",
                 label="Workfiles Start Frame",
                 tooltip="Set workfile starting frame number",
-                default=presets.get("workfileFrameStart", 1001),
+                default=self.presets["workfileFrameStart"],
             ),
             NumberDef(
                 "handleStart",
                 label="Handle Start (head)",
                 tooltip="Handle at start of clip",
-                default=presets.get("handleStart", 0),
+                default=self.presets["handleStart"],
             ),
             NumberDef(
                 "handleEnd",
                 label="Handle End (tail)",
                 tooltip="Handle at end of clip",
-                default=presets.get("handleEnd", 0),
+                default=self.presets["handleEnd"],
             ),
         ]
 

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -116,11 +116,7 @@ class _ResolveInstanceClipCreator(HiddenResolvePublishCreator):
         Return:
             CreatedInstance: The created instance object for the new shot.
         """
-        instance_data.update({
-            "newHierarchyIntegration": True,
-            # Backwards compatible (Deprecated since 24/06/06)
-            "newAssetPublishing": True,
-        })
+        instance_data["newHierarchyIntegration"] = True
 
         new_instance = CreatedInstance(
             self.product_type, instance_data["productName"], instance_data, self

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -118,8 +118,15 @@ class _ResolveInstanceClipCreator(HiddenResolvePublishCreator):
         """
         instance_data["newHierarchyIntegration"] = True
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         new_instance = CreatedInstance(
-            self.product_type, instance_data["productName"], instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=instance_data["productName"],
+            data=instance_data,
+            creator=self,
         )
         self._add_instance_to_context(new_instance)
         new_instance.transient_data["has_promised_context"] = True

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -450,12 +450,6 @@ OTIO file.
                 items=['<track_name>', 'main', 'bg', 'fg', 'bg', 'animatic'],
             ),
             EnumDef(
-                "productType",
-                label="Product Type",
-                tooltip="How the product will be used",
-                items=['plate'],  # it is prepared for more types
-            ),
-            EnumDef(
                 "reviewableSource",
                 label="Reviewable Source",
                 tooltip="Selecting source for reviewable files.",

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -685,6 +685,8 @@ OTIO file.
                             f"{sub_instance_data['productName']}"
                         )
                     })
+                    sub_instance_data["productType"] = "plate"
+                    sub_instance_data["productBaseType"] = "plate"
                     creator_attributes["parentInstance"] = parenting_data[
                         "label"]
                     if sub_instance_data.get("reviewableSource"):

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -166,8 +166,8 @@ class _ResolveInstanceClipCreator(plugin.HiddenResolvePublishCreator):
 class ResolveShotInstanceCreator(_ResolveInstanceClipCreator):
     """Shot product type creator class"""
     identifier = "io.ayon.creators.resolve.shot"
-    product_type = "shot"
     product_base_type = "shot"
+    product_type = product_base_type
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -265,16 +265,16 @@ class _ResolveInstanceClipCreatorBase(_ResolveInstanceClipCreator):
 class EditorialPlateInstanceCreator(_ResolveInstanceClipCreatorBase):
     """Plate product type creator class"""
     identifier = "io.ayon.creators.resolve.plate"
-    product_type = "plate"
     product_base_type = "plate"
+    product_type = product_base_type
     label = "Editorial Plate"
 
 
 class EditorialAudioInstanceCreator(_ResolveInstanceClipCreatorBase):
     """Audio product type creator class"""
     identifier = "io.ayon.creators.resolve.audio"
-    product_type = "audio"
     product_base_type = "audio"
+    product_type = product_base_type
     label = "Editorial Audio"
 
 
@@ -283,8 +283,8 @@ class CreateShotClip(plugin.ResolveCreator):
 
     identifier = "io.ayon.creators.resolve.clip"
     label = "Create Publishable Clip"
-    product_type = "editorial"
     product_base_type = "editorial"
+    product_type = product_base_type
     icon = "film"
     defaults = ["Main"]
 

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -107,7 +107,7 @@ class _ResolveInstanceClipCreator(HiddenResolvePublishCreator):
     """
     skip_discovery = True
 
-    def create(self, instance_data, _):
+    def create(self, instance_data):
         """Return a new CreateInstance for new shot from Resolve.
 
         Args:
@@ -716,7 +716,7 @@ OTIO file.
                     if sub_instance_data.get("reviewableSource"):
                         creator_attributes["review"] = True
 
-                instance = creator.create(sub_instance_data, None)
+                instance = creator.create(sub_instance_data)
                 instance.transient_data["track_item"] = track_item
                 self._add_instance_to_context(instance)
 
@@ -773,7 +773,7 @@ OTIO file.
             }
             data["creator_attributes"] = creator_attributes
 
-        instance = creator.create(data, None)
+        instance = creator.create(data)
         instance.transient_data["track_item"] = timeline_item
         self._add_instance_to_context(instance)
         instances.append(instance)

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -169,7 +169,7 @@ class _ResolveInstanceClipCreator(HiddenResolvePublishCreator):
             self._remove_instance_from_context(instance)
 
             # Remove markers if deleted all of the instances
-            if not instances_data: 
+            if not instances_data:
                 track_item.DeleteMarkersByColor(constants.AYON_MARKER_COLOR)
                 if track_item.GetClipColor() != constants.SELECTED_CLIP_COLOR:
                     track_item.ClearClipColor()
@@ -306,7 +306,7 @@ class CreateShotClip(ResolveCreator):
 
     detailed_description = """
 Publishing clips/plate, audio for new shots to project
-or updating already created from Resolve. Publishing will create 
+or updating already created from Resolve. Publishing will create
 OTIO file.
 """
     create_allow_thumbnail = False
@@ -446,6 +446,9 @@ OTIO file.
             UILabelDef(
                 label=header_label("Clip Publish Settings")
             ),
+            self._add_product_type_enum(
+                ("plate", "Plate", "plate_product_type")
+            ),
             EnumDef(
                 "clip_variant",
                 label="Product Variant",
@@ -471,6 +474,9 @@ OTIO file.
                 label="Include audio",
                 tooltip="Process products with corresponding audio",
                 default=False,
+            ),
+            self._add_product_type_enum(
+                ("audio", "Audio", "audio_product_type")
             ),
             BoolDef(
                 "sourceResolution",
@@ -502,25 +508,37 @@ OTIO file.
                 default=self.presets["handleEnd"],
             ),
         ]
-
-        for base_type, type_label, def_key in (
-            ("plate", "Plate", "plate_product_type"),
-            ("audio", "Audio", "audio_product_type"),
-        ):
-            presets_key = f"{def_key}s"
-            product_types = self.presets[presets_key]
-            if product_types:
-                output.append(
-                    EnumDef(
-                        def_key,
-                        label=f"{type_label} Product Type",
-                        tooltip=f"Select product type for {base_type}",
-                        items=product_types,
-                        default=product_types[0],
-                    )
-                )
-
         return output
+
+    def _add_product_type_enum(
+            self, type_def: tuple[str, str, str]) -> EnumDef:
+        """Add product type enum definition for a given type.
+
+        Args:
+            type_def (tuple[str, str, str]): A tuple containing
+                the base type, type label, and definition key.
+
+        Returns:
+            EnumDef: The enum definition for the product type.
+        """
+        base_type, type_label, def_key = type_def
+        presets_key = f"{def_key}s"
+        product_types = self.presets[presets_key]
+        if not product_types:
+            return EnumDef(
+                def_key,
+                label=f"{type_label} Product Type",
+                tooltip=f"Select product type for {base_type}",
+                items=[base_type],
+                default=base_type,
+            )
+        return EnumDef(
+            def_key,
+            label=f"{type_label} Product Type",
+            tooltip=f"Select product type for {base_type}",
+            items=product_types,
+            default=product_types[0],
+        )
 
     def create(self, product_name, instance_data, pre_create_data):
         super().create(
@@ -876,7 +894,7 @@ OTIO file.
                     tag_data, timeline_item, instances)
                 continue
 
-            # get AyonData tag data 
+            # get AyonData tag data
             tag_data = lib.get_timeline_item_ayon_tag(timeline_item)
             if not tag_data:
                 continue

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -447,7 +447,7 @@ OTIO file.
                 label=header_label("Clip Publish Settings")
             ),
             self._add_product_type_enum(
-                ("plate", "Plate", "plate_product_type")
+                "plate", "Plate", "plate_product_type"
             ),
             EnumDef(
                 "clip_variant",
@@ -476,7 +476,7 @@ OTIO file.
                 default=False,
             ),
             self._add_product_type_enum(
-                ("audio", "Audio", "audio_product_type")
+                "audio", "Audio", "audio_product_type"
             ),
             BoolDef(
                 "sourceResolution",
@@ -511,27 +511,21 @@ OTIO file.
         return output
 
     def _add_product_type_enum(
-            self, type_def: tuple[str, str, str]) -> EnumDef:
+        self, base_type: str, type_label: str, def_key: str
+    ) -> EnumDef:
         """Add product type enum definition for a given type.
 
         Args:
-            type_def (tuple[str, str, str]): A tuple containing
+            base_type (str): A tuple containing
                 the base type, type label, and definition key.
 
         Returns:
             EnumDef: The enum definition for the product type.
         """
-        base_type, type_label, def_key = type_def
         presets_key = f"{def_key}s"
         product_types = self.presets[presets_key]
         if not product_types:
-            return EnumDef(
-                def_key,
-                label=f"{type_label} Product Type",
-                tooltip=f"Select product type for {base_type}",
-                items=[base_type],
-                default=base_type,
-            )
+            product_types = [base_type]
         return EnumDef(
             def_key,
             label=f"{type_label} Product Type",

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -446,7 +446,7 @@ OTIO file.
             UILabelDef(
                 label=header_label("Clip Publish Settings")
             ),
-            self._add_product_type_enum(
+            self._get_product_type_enum(
                 "plate", "Plate", "plate_product_type"
             ),
             EnumDef(
@@ -475,7 +475,7 @@ OTIO file.
                 tooltip="Process products with corresponding audio",
                 default=False,
             ),
-            self._add_product_type_enum(
+            self._get_product_type_enum(
                 "audio", "Audio", "audio_product_type"
             ),
             BoolDef(
@@ -510,14 +510,15 @@ OTIO file.
         ]
         return output
 
-    def _add_product_type_enum(
-        self, base_type: str, type_label: str, def_key: str
+    def _get_product_type_enum(
+        self, product_base_type: str, label: str, def_key: str
     ) -> EnumDef:
         """Add product type enum definition for a given type.
 
         Args:
-            base_type (str): A tuple containing
-                the base type, type label, and definition key.
+            product_base_type (str): Product base type.
+            label (str): Product type label.
+            def_key (str): Definition key for product type.
 
         Returns:
             EnumDef: The enum definition for the product type.
@@ -525,11 +526,11 @@ OTIO file.
         presets_key = f"{def_key}s"
         product_types = self.presets[presets_key]
         if not product_types:
-            product_types = [base_type]
+            product_types = [product_base_type]
         return EnumDef(
             def_key,
-            label=f"{type_label} Product Type",
-            tooltip=f"Select product type for {base_type}",
+            label=f"{label} Product Type",
+            tooltip=f"Select product type for {product_base_type}",
             items=product_types,
             default=product_types[0],
         )

--- a/client/ayon_resolve/plugins/create/create_shot_clip.py
+++ b/client/ayon_resolve/plugins/create/create_shot_clip.py
@@ -597,6 +597,10 @@ OTIO file.
             pre_create_data.get("audio_product_type")
             or EditorialAudioInstanceCreator.product_base_type
         )
+
+        pre_create_data["plate_product_type"] = plate_product_type
+        pre_create_data["audio_product_type"] = audio_product_type
+
         for index, track_item_data in enumerate(sorted_selected_track_items):
 
             # Compute and store resolution metadata from mediapool clip.

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -63,24 +63,12 @@ class CreateWorkfile(AutoCreator):
             variant=self.default_variant,
             host_name=host_name,
         )
-        data = {
+        return {
             "folderPath": folder_path,
             "task": task_name,
             "variant": variant,
             "productName": product_name,
         }
-        data.update(
-            self.get_dynamic_data(
-                variant,
-                task_name,
-                folder_entity,
-                project_name,
-                host_name,
-                False,
-            )
-        )
-
-        return data
 
     def collect_instances(self):
         """Collect from timeline marker or create a new one."""

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -89,7 +89,12 @@ class CreateWorkfile(AutoCreator):
             return
 
         current_instance = CreatedInstance(
-            self.product_type, data["productName"], data, self)
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=data["productName"],
+            data=data,
+            creator=self,
+        )
         self._add_instance_to_context(current_instance)
 
     def create(self, options=None):
@@ -101,7 +106,12 @@ class CreateWorkfile(AutoCreator):
         self.log.info("Auto-creating workfile instance...")
         data = self._create_new_instance()
         current_instance = CreatedInstance(
-            self.product_type, data["productName"], data, self)
+            product_base_type=self.product_base_type,
+            product_type=self.product_type,
+            product_name=data["productName"],
+            data=data,
+            creator=self,
+        )
         self._add_instance_to_context(current_instance)
 
     def update_instances(self, update_list):

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -16,8 +16,8 @@ class CreateWorkfile(AutoCreator):
 
     identifier = "io.ayon.creators.resolve.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
 
     default_variant = "Main"
 

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -97,7 +97,7 @@ class CreateWorkfile(AutoCreator):
         )
         self._add_instance_to_context(current_instance)
 
-    def create(self, options=None):
+    def create(self):
         """Auto-create an instance by default."""
         data = self._loads_data_from_project_setting()
         if data:

--- a/client/ayon_resolve/plugins/load/load_clip.py
+++ b/client/ayon_resolve/plugins/load/load_clip.py
@@ -18,7 +18,8 @@ class LoadClip(plugin.TimelineItemLoader):
     during conforming to project
     """
 
-    product_types = {"render2d", "source", "plate", "render", "review"}
+    product_base_types = {"render2d", "source", "plate", "render", "review"}
+    product_types = product_base_types
 
     representations = {"*"}
     extensions = set(

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -19,7 +19,8 @@ class LoadEditorialPackage(load.LoaderPlugin):
     and timeline structure.
     """
 
-    product_types = {"editorial_pkg"}
+    product_base_types = {"editorial_pkg"}
+    product_types = product_base_types
 
     representations = {"*"}
     extensions = {"otio"}

--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -138,11 +138,17 @@ def find_clip_usage(media_pool_item, project=None):
 class LoadMedia(LoaderPlugin):
     """Load product as media pool item."""
 
-    product_types = {"render2d", "source", "plate", "render", "review", "audio", "image"}
+    product_base_types = {
+        "render2d", "source", "plate", "render", "review", "audio", "image"
+    }
+    product_types = product_base_types
 
     representations = ["*"]
     extensions = set(
-        ext.lstrip(".") for ext in IMAGE_EXTENSIONS.union(VIDEO_EXTENSIONS, RESOLVE_AUDIO_EXTENSIONS)
+        ext.lstrip(".")
+        for ext in (
+            IMAGE_EXTENSIONS | VIDEO_EXTENSIONS | RESOLVE_AUDIO_EXTENSIONS
+        )
     )
 
     label = "Load media"

--- a/server/settings.py
+++ b/server/settings.py
@@ -72,6 +72,16 @@ class CreateShotClipModels(BaseSettingsModel):
         10,
         title="Handle end (tail)"
     )
+    plate_product_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Plate Product types",
+        description="Optional list of product types for plate products."
+    )
+    audio_product_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Audio Product types",
+        description="Optional list of product types for audio products."
+    )
 
 
 class CreatorPluginsModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of Resolve addon is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Shot create plugin have option to define custom product types for plate and audio instances.

Side changes:
- Moved override of `apply_settings` to the only create plugin which actually uses it.
- Removed some backwards compatibily (classes `Creator` and `PublishClip`).
- Use 'product' instead of 'subset'.
- Marked base classes to be skipped during discovery.
- Don't use "safe getters" for settings to make sure settings are actually used.

## Testing notes:
This is untested PR from my side, please make sure it is fully reviewed.
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Upload the addon to server to use new settings model.
3. Existing workfiles should load up and should be possible to publish.
4. Creating new instances should work as expected.

### Product types
1. Define product types for plate and audio in settings.
2. Publisher should show selection of them in pre-create attributes.
3. Create them.
5. Product name should use the product type in name (if template defines that).
6. Publish the instances.
7. Loader tool should show the product type and product base type in UI.