### PR TITLE
Chore: Remove backwards compatibility

### DIFF
--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -33,7 +33,6 @@ from .lib import (
     get_video_track_names,
     get_current_timeline_items,
     get_timeline_item_by_name,
-    get_pype_timeline_item_by_name,  # backward compatibility
     get_timeline_item_ayon_tag,
     set_timeline_item_ayon_tag,
     set_timeline_item_pype_tag,  # backward compatibility
@@ -117,7 +116,6 @@ __all__ = [
     "get_video_track_names",
     "get_current_timeline_items",
     "get_timeline_item_by_name",
-    "get_pype_timeline_item_by_name",  # backward compatibility
     "get_timeline_item_ayon_tag",
     "set_timeline_item_ayon_tag",
     "set_timeline_item_pype_tag",  # backward compatibility

--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -18,7 +18,6 @@ from .lib import (
     maintain_current_timeline,
     get_project_manager,
     get_current_resolve_project,
-    get_current_project, # backward compatibility
     get_current_timeline,
     get_any_timeline,
     get_new_timeline,
@@ -100,7 +99,6 @@ __all__ = [
     "maintain_current_timeline",
     "get_project_manager",
     "get_current_resolve_project",
-    "get_current_project", # backward compatibility
     "get_current_timeline",
     "get_any_timeline",
     "get_new_timeline",

--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -35,7 +35,6 @@ from .lib import (
     get_timeline_item_by_name,
     get_timeline_item_ayon_tag,
     set_timeline_item_ayon_tag,
-    set_timeline_item_pype_tag,  # backward compatibility
     imprint,
     set_publish_attribute,
     get_publish_attribute,
@@ -118,7 +117,6 @@ __all__ = [
     "get_timeline_item_by_name",
     "get_timeline_item_ayon_tag",
     "set_timeline_item_ayon_tag",
-    "set_timeline_item_pype_tag",  # backward compatibility
     "imprint",
     "set_publish_attribute",
     "get_publish_attribute",

--- a/client/ayon_resolve/api/__init__.py
+++ b/client/ayon_resolve/api/__init__.py
@@ -35,7 +35,6 @@ from .lib import (
     get_timeline_item_by_name,
     get_pype_timeline_item_by_name,  # backward compatibility
     get_timeline_item_ayon_tag,
-    get_timeline_item_pype_tag,  # backward compatibility
     set_timeline_item_ayon_tag,
     set_timeline_item_pype_tag,  # backward compatibility
     imprint,
@@ -120,7 +119,6 @@ __all__ = [
     "get_timeline_item_by_name",
     "get_pype_timeline_item_by_name",  # backward compatibility
     "get_timeline_item_ayon_tag",
-    "get_timeline_item_pype_tag",  # backward compatibility
     "set_timeline_item_ayon_tag",
     "set_timeline_item_pype_tag",  # backward compatibility
     "imprint",

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -533,10 +533,11 @@ def get_timeline_item_by_name(name: str) -> object:
 
     Returns:
         object: resolve.TimelineItem
+
     """
     for _ti_data in get_current_timeline_items():
         _ti_clip = _ti_data["clip"]["item"]
-        tag_data = get_timeline_item_pype_tag(_ti_clip)
+        tag_data = get_timeline_item_ayon_tag(_ti_clip)
         tag_name = tag_data.get("namespace")
         if not tag_name:
             continue
@@ -576,9 +577,6 @@ def get_timeline_item_ayon_tag(timeline_item):
                 return_tag = json.loads(data)
 
     return return_tag
-
-# alias for backward compatibility
-get_timeline_item_pype_tag = get_timeline_item_ayon_tag
 
 
 def set_timeline_item_ayon_tag(timeline_item, data=None):

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -163,9 +163,6 @@ def get_current_resolve_project():
     project_manager = get_project_manager()
     return project_manager.GetCurrentProject()
 
-# alias for backward compatibility
-get_current_project = get_current_resolve_project
-
 
 def get_current_timeline(new=False):
     """Get current timeline object.
@@ -1178,7 +1175,7 @@ def iter_all_media_pool_clips(root=None):
         root (Optional[resolve.Folder]): root folder / bin object.
             When None, defaults to media pool root folder.
     """
-    root = root or get_current_project().GetMediaPool().GetRootFolder()
+    root = root or get_current_resolve_project().GetMediaPool().GetRootFolder()
     queue = [root]
     for folder in queue:
         for clip in folder.GetClipList():

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -546,10 +546,6 @@ def get_timeline_item_by_name(name: str) -> object:
     return None
 
 
-# alias for backward compatibility
-get_pype_timeline_item_by_name = get_timeline_item_by_name
-
-
 def get_timeline_item_ayon_tag(timeline_item):
     """
     Get ayon track item tag created by creator or loader plugin.

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -507,7 +507,8 @@ def get_current_timeline_items(
             "track": {
                 "name": _track_name,
                 "index": track_index,
-                "type": track_type}
+                "type": track_type,
+            }
         }
         # get track item object and its color
         for clip_index, ti in enumerate(_clips[track_index]):
@@ -547,11 +548,12 @@ def get_timeline_item_ayon_tag(timeline_item):
     """
     Get ayon track item tag created by creator or loader plugin.
 
-    Attributes:
-        trackItem (resolve.TimelineItem): resolve object
+    Args:
+        timeline_item (resolve.TimelineItem): resolve object
 
     Returns:
         dict: ayon tag data
+
     """
     return_tag = None
 

--- a/client/ayon_resolve/api/lib.py
+++ b/client/ayon_resolve/api/lib.py
@@ -614,10 +614,6 @@ def set_timeline_item_ayon_tag(timeline_item, data=None):
     return tag_data
 
 
-# alias for backward compatibility
-set_timeline_item_pype_tag = set_timeline_item_ayon_tag
-
-
 def imprint(timeline_item, data=None):
     """
     Adding `Ayon data` into a timeline item track item tag.

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -35,7 +35,7 @@ class ClipLoader:
         """
         self.__dict__.update(loader_obj.__dict__)
         self.context = context
-        self.active_project = lib.get_current_project()
+        self.active_project = lib.get_current_resolve_project()
 
         # try to get value from options or evaluate key value for `handles`
         self.with_handles = options.get("handles") is True

--- a/client/ayon_resolve/api/rendering.py
+++ b/client/ayon_resolve/api/rendering.py
@@ -9,7 +9,7 @@ from pprint import pformat
 from ayon_core.lib import Logger
 
 from .lib import (
-    get_current_project,
+    get_current_resolve_project,
     maintain_current_timeline,
     maintain_page_by_name,
 )
@@ -45,7 +45,7 @@ def _render_timelines(timelines, target_render_directory):
     Returns:
         bool: True if all renders are successful, False otherwise
     """
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     failed_timelines = []
     for timeline_to_render in timelines:
         with maintain_current_timeline(timeline_to_render):
@@ -80,7 +80,7 @@ def render_all_timelines(target_render_directory):
     Returns:
         bool: True if all renders are successful, False otherwise
     """
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     with maintain_page_by_name("Deliver"):
         timelineCount = bmr_project.GetTimelineCount()
         all_timelines = [
@@ -109,7 +109,7 @@ def render_single_timeline(timeline, target_render_directory):
 
 def is_rendering_in_progress():
     """Check if rendering is in progress"""
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     if not bmr_project:
         return False
 
@@ -133,7 +133,7 @@ def apply_drx_to_all_timeline_items(timeline, path, grade_mode=0):
 
 
 def apply_drx_to_all_timelines(path, grade_mode=0):
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     if not bmr_project:
         return False
     timelineCount = bmr_project.GetTimelineCount()
@@ -148,7 +148,7 @@ def apply_drx_to_all_timelines(path, grade_mode=0):
 
 def delete_all_processed_jobs():
     """Delete all processed jobs"""
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     if not _PROCESSING_JOBS:
         return
 
@@ -161,7 +161,7 @@ def delete_all_processed_jobs():
 def set_render_preset_from_file(preset_file_path):
     from . import bmdvr
 
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
     preset_path = Path(preset_file_path)
 
     # make sure the file exists
@@ -184,7 +184,7 @@ def set_render_preset_from_file(preset_file_path):
 
 
 def set_format_and_codec(render_format, render_codec):
-    bmr_project = get_current_project()
+    bmr_project = get_current_resolve_project()
 
     available_render_formats = bmr_project.GetRenderFormats()
     log.debug(f"Available formats: {pformat(available_render_formats)}")

--- a/client/ayon_resolve/plugins/create/create_workfile.py
+++ b/client/ayon_resolve/plugins/create/create_workfile.py
@@ -32,12 +32,12 @@ class CreateWorkfile(AutoCreator):
         # https://forum.blackmagicdesign.com/viewtopic.php?f=21&t=
         # 189685&hilit=python+database#p991541
         note = json.dumps(data)
-        proj = lib.get_current_project()
+        proj = lib.get_current_resolve_project()
         proj.SetSetting("colorVersion10Name", note)
 
     def _loads_data_from_project_setting(self):
         """Retrieve workfile data from project setting."""
-        proj = lib.get_current_project()
+        proj = lib.get_current_resolve_project()
         setting_content = proj.GetSetting("colorVersion10Name")
 
         if setting_content:

--- a/client/ayon_resolve/plugins/load/load_editorial_package.py
+++ b/client/ayon_resolve/plugins/load/load_editorial_package.py
@@ -36,7 +36,7 @@ class LoadEditorialPackage(load.LoaderPlugin):
         if not search_folder_path.exists():
             search_folder_path = Path(files).parent
 
-        project = lib.get_current_project()
+        project = lib.get_current_resolve_project()
         media_pool = project.GetMediaPool()
         folder_path = context["folder"]["path"]
 

--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -52,7 +52,7 @@ def project_color_science_mode(project=None, mode="davinciYRGBColorManagedv2"):
     """
 
     if project is None:
-        project = lib.get_current_project()
+        project = lib.get_current_resolve_project()
 
     original_mode = project.GetSetting("colorScienceMode")
     if original_mode != mode:
@@ -107,7 +107,7 @@ def find_clip_usage(media_pool_item, project=None):
         return []
 
     if project is None:
-        project = lib.get_current_project()
+        project = lib.get_current_resolve_project()
 
     matching_items = []
     unique_id = media_pool_item.GetUniqueId()
@@ -196,7 +196,7 @@ class LoadMedia(LoaderPlugin):
         representation = context["representation"]
         self._project_name = context["project"]["name"]
 
-        project = lib.get_current_project()
+        project = lib.get_current_resolve_project()
         media_pool = project.GetMediaPool()
 
         # Allow to use an existing media pool item and re-use it
@@ -340,7 +340,7 @@ class LoadMedia(LoaderPlugin):
 
     def remove(self, container):
         # Remove MediaPoolItem entry
-        project = lib.get_current_project()
+        project = lib.get_current_resolve_project()
         media_pool = project.GetMediaPool()
         item = container["_item"]
 

--- a/client/ayon_resolve/plugins/publish/collect_shots.py
+++ b/client/ayon_resolve/plugins/publish/collect_shots.py
@@ -91,7 +91,7 @@ class CollectShot(pyblish.api.InstancePlugin):
 
             except KeyError:
                 # Retrieve resolution for project.
-                project = lib.get_current_project()
+                project = lib.get_current_resolve_project()
                 project_settings = project.GetSetting()
                 try:
                     pixel_aspect = int(project_settings["timelinePixelAspectRatio"])

--- a/client/ayon_resolve/plugins/publish/extract_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/extract_editorial_package.py
@@ -6,7 +6,7 @@ import opentimelineio as otio
 from ayon_core.pipeline import publish
 from ayon_resolve.api.lib import (
     maintain_current_timeline,
-    get_current_project,
+    get_current_resolve_project,
     export_timeline_otio_native
 )
 from ayon_resolve.otio import davinci_export
@@ -61,7 +61,7 @@ class ExtractEditorialPackage(publish.Extractor):
 
             # export otio representation
             self.export_otio_representation(
-                get_current_project(), timeline, otio_file_path
+                get_current_resolve_project(), timeline, otio_file_path
             )
 
         # Find Intermediate file representation file name

--- a/client/ayon_resolve/utility_scripts/develop/test_rendering_editorial_package.py
+++ b/client/ayon_resolve/utility_scripts/develop/test_rendering_editorial_package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ayon_core.lib import Logger
 
 from ayon_resolve.api.lib import (
-    get_current_project,
+    get_current_resolve_project,
     maintain_page_by_name,
 )
 from ayon_resolve.api.rendering import (
@@ -47,7 +47,7 @@ def main(
             log.error("Unable to set render format and codec.")
             sys.exit()
 
-        timeline = get_current_project().GetCurrentTimeline()
+        timeline = get_current_resolve_project().GetCurrentTimeline()
 
         if not render_single_timeline(
             timeline,

--- a/package.py
+++ b/package.py
@@ -7,6 +7,6 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.0.1",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Remove backwards compatible functions.

## Additional review information
I'm not sure why the functions were kept in codebase as they are not used out of the addon codebase.
Removes:
- `get_current_project`
- `get_pype_timeline_item_by_name`
- `get_timeline_item_pype_tag`
- `set_timeline_item_pype_tag`

## Testing notes:
1. Everything should be working.
