### PR TITLE
OTIO: Skip decoding marker note to JSON if JSON decoding failed

### DIFF
--- a/client/ayon_resolve/otio/utils.py
+++ b/client/ayon_resolve/otio/utils.py
@@ -1,6 +1,9 @@
 import json
 import re
 import opentimelineio as otio
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def timecode_to_frames(timecode, framerate):
@@ -86,8 +89,11 @@ def unwrap_resolve_otio_marker(marker):
         marker_note = marker.metadata["Resolve_OTIO"]["Note"]
     except KeyError:
         return marker
-
-    marker_note_dict = json.loads(marker_note)
+    try:
+        marker_note_dict = json.loads(marker_note)
+    except json.decoder.JSONDecodeError:
+        log.warning("Failed to decode marker note as JSON: %s", marker_note)
+        return marker
     marker.metadata.update(marker_note_dict)  # prevent additional resolve keys
     return marker
 


### PR DESCRIPTION
## Changelog Description

OTIO: Skip decoding marker note to JSON if JSON decoding failed

## Additional review information

Avoids:
```python
Traceback (most recent call last):
  File "C:\Users\ernkow\AppData\Local\Ynput\AYON\dependency_packages\ayon_2510271030_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "C:\Users\ernkow\AppData\Local\Ynput\AYON\addons\resolve_0.5.7\ayon_resolve\plugins\publish\collect_shots.py", line 59, in process
    otio_clip, marker = utils.get_marker_from_clip_index(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ernkow\AppData\Local\Ynput\AYON\addons\resolve_0.5.7\ayon_resolve\otio\utils.py", line 114, in get_marker_from_clip_index
    marker = unwrap_resolve_otio_marker(marker)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ernkow\AppData\Local\Ynput\AYON\addons\resolve_0.5.7\ayon_resolve\otio\utils.py", line 90, in unwrap_resolve_otio_marker
    marker_note_dict = json.loads(marker_note)
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ernkow\AppData\Local\Programs\Python\Python312\Lib\json\__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ernkow\AppData\Local\Programs\Python\Python312\Lib\json\decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ernkow\AppData\Local\Programs\Python\Python312\Lib\json\decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Testing notes:

1. Not sure how to reproduce, but check the code?
