### PR TITLE
Fix nested timelines breaking export of editorial package

### DIFF
--- a/client/ayon_resolve/plugins/publish/extract_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/extract_editorial_package.py
@@ -86,7 +86,7 @@ class ExtractEditorialPackage(publish.Extractor):
                 if isinstance(clip, otio.schema.Gap):
                     # get duration of gap
                     continue
-                # skip stacks (nested timelines)
+                # skip stacks (nested timelines, Fusion clips, etc.)
                 if isinstance(clip, otio.schema.Stack):
                     continue
 

--- a/client/ayon_resolve/plugins/publish/extract_editorial_package.py
+++ b/client/ayon_resolve/plugins/publish/extract_editorial_package.py
@@ -86,7 +86,12 @@ class ExtractEditorialPackage(publish.Extractor):
                 if isinstance(clip, otio.schema.Gap):
                     # get duration of gap
                     continue
+                # skip stacks (nested timelines)
+                if isinstance(clip, otio.schema.Stack):
+                    continue
 
+                # TODO: Instead of skipping other class types should we just
+                #  check for isinstance(clip, otio.schema.Clip)?
                 if hasattr(clip.media_reference, "target_url"):
                     path_to_media = Path(published_file_path)
                     # remove root from path


### PR DESCRIPTION
## Changelog Description

Fix nested timelines breaking export of editorial package

## Additional review information

Fix #86 : seems like that error doesn't actually happen due to unlinked media.

## Testing notes:

1. Publishing editorial package with timeline in the timeline should not error.
