### PR TITLE
Fallback to SetMetadata if SetClipProperty fails

### DIFF
--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -416,15 +416,20 @@ class LoadMedia(LoaderPlugin):
             clip_property = meta_item["name"]
             value = meta_item["value"]
             value_formatted = StringTemplate(value).format_strict(context)
-            success = media_pool_item.SetClipProperty(
-                clip_property, value_formatted)
-            if not bool(success):
-                try:
-                    media_pool_item.SetMetadata(clip_property, value_formatted)
-                except Exception as e:
+            is_set = media_pool_item.SetClipProperty(
+                clip_property,
+                value_formatted
+            )
+            if not is_set:
+                # Allow to set metadata instead of clip property using the same
+                # configuration in settings.
+                is_set = media_pool_item.SetMetadata(clip_property,
+                                                     value_formatted)
+                if not is_set:
                     self.log.warning(
-                        f"Failed to set metadata {clip_property} to "
-                        f"{value_formatted}\n{e}.")
+                        "Failed to set clip property or metadata"
+                        f" '{clip_property}': '{value_formatted}'"
+                    )
 
     def _get_file_info(self, context: dict) -> Tuple[bool, Union[str, dict]]:
         """Return file info for Resolve ImportMedia.

--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -416,7 +416,15 @@ class LoadMedia(LoaderPlugin):
             clip_property = meta_item["name"]
             value = meta_item["value"]
             value_formatted = StringTemplate(value).format_strict(context)
-            media_pool_item.SetClipProperty(clip_property, value_formatted)
+            success = media_pool_item.SetClipProperty(
+                clip_property, value_formatted)
+            if not bool(success):
+                try:
+                    media_pool_item.SetMetadata(clip_property, value_formatted)
+                except Exception as e:
+                    self.log.warning(
+                        f"Failed to set metadata {clip_property} to "
+                        f"{value_formatted}\n{e}.")
 
     def _get_file_info(self, context: dict) -> Tuple[bool, Union[str, dict]]:
         """Return file info for Resolve ImportMedia.


### PR DESCRIPTION
When applying metadata to media pool items in DaVinci Resolve, some properties may not be accepted by the SetClipProperty method. This adds a fallback attempt using SetMetadata to ensure more metadata fields are successfully applied.

## Additional review information
Fix https://github.com/ynput/ayon-resolve/issues/90

## Testing notes:
1. In Resolve Metadata mapping, set some value for properties Take and Move
2. Both properties should be set when loading / updating new media to Resolve
