### PR TITLE
Improve marker unwrap robustness for missing metadata

### DIFF
--- a/client/ayon_resolve/otio/utils.py
+++ b/client/ayon_resolve/otio/utils.py
@@ -83,8 +83,12 @@ def unwrap_resolve_otio_marker(marker):
     # dict metadata for some reasons.
     # {dict_info} -> {"Resolve_OTIO": {"Note": "string_dict_info"}}
     try:
-        marker_note = marker.metadata["Resolve_OTIO"]["Note"]
-    except KeyError:
+        resolve_otio = marker.metadata.get("Resolve_OTIO")
+        marker_note = resolve_otio.get("Note")
+    except (KeyError, AttributeError):
+        return marker
+
+    if not marker_note:
         return marker
 
     marker_note_dict = json.loads(marker_note)
@@ -111,8 +115,8 @@ def get_marker_from_clip_index(otio_timeline, clip_index):
     # See collect_current_project
     for otio_clip in all_clips:
         for marker in otio_clip.markers:
-            marker = unwrap_resolve_otio_marker(marker)
-            if marker.metadata.get("clip_index") == clip_index:
-                return  otio_clip, marker
+            marker_ = unwrap_resolve_otio_marker(marker)
+            if marker_.metadata.get("clip_index") == clip_index:
+                return otio_clip, marker_
 
     return None, None


### PR DESCRIPTION
## Changelog Description
Enhanced marker unwrapping to gracefully handle missing or incomplete OTIO metadata. The function now safely returns the original marker when `Resolve_OTIO` metadata or its `Note` field is absent, preventing data loss and improving reliability.

## Additional info
BlackMagic had changed the way Markers are stored and for unknown reason AYONdata markers are stored in native OTIO exporter as two markers with first of them being without the Note json dump. This started to create Json decoding raises. 

**Code changes:**
- Replaced direct key access with `.get()` for safer metadata retrieval
- Added `AttributeError` to exception handling for null safety
- Added explicit check for empty marker_note value
- Refactored variable naming to prevent shadowing

## Testing notes:
1. Test publishing workflow on newest BMD Resolve 19.5 >
2. Publishing will not be blocked by Collect Shots plugin on JSON decoding error Traceback
