### PR TITLE
Load Media: Fix KeyError raised by missing colorspace in verison entity

### DIFF
--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -386,6 +386,8 @@ class LoadMedia(LoaderPlugin):
             "handleStart", "handleEnd",
             "source", "fps", "colorSpace"
         ]:
+            if key not in version["attrib"]:
+                continue
             data[key] = version["attrib"][key]
 
         # version.data


### PR DESCRIPTION
## Changelog Description
This PR is to make sure media loader would not raise any KeyError and keep loading the media when there is missing colorspace data in the context to be loaded.

Fixes https://github.com/ynput/ayon-resolve/issues/99

## Additional review information
n/a

## Testing notes:
1. Launch Resolve
2. Load Media
