### PR TITLE
fix: prevent KeyError during media load by safely retrieving version attributes

### DIFF
--- a/client/ayon_resolve/plugins/load/load_media.py
+++ b/client/ayon_resolve/plugins/load/load_media.py
@@ -386,7 +386,7 @@ class LoadMedia(LoaderPlugin):
             "handleStart", "handleEnd",
             "source", "fps", "colorSpace"
         ]:
-            data[key] = version["attrib"][key]
+            data[key] = version["attrib"].get(key)
 
         # version.data
         if "author" in version["data"]:


### PR DESCRIPTION
## Changelog Description

Fixes a `KeyError` crash when loading media in DaVinci Resolve that lacks optional metadata attributes.

## Additional review information

Updated `client/ayon_resolve/plugins/load/load_media.py` to use `.get(key)` instead of direct dictionary access for version attributes. This prevents the loader from breaking if attributes like `colorSpace` or `handleStart` are missing from the publish payload, defaulting them gracefully to `None` instead.

## Testing notes:

1. Launch DaVinci Resolve through AYON.
2. Attempt to load a published media version that is missing optional attributes (like `colorSpace` or `handleStart`) in its database payload.
3. **Without PR:** The process fails and throws a `KeyError`.
4. **With PR:** The media loads successfully into the Resolve timeline.
