### PR TITLE
Fix staging directory path for product resources

### DIFF
--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -264,7 +264,7 @@ class ExtractProductResources(
             representation.update({
                 "ext":        rendered.suffix.lstrip(".").lower(),
                 "files":      rendered.name,
-                "stagingDir": str(rendered),
+                "stagingDir": str(rendered.parent),
             })
 
         # attach colorspace to the representation


### PR DESCRIPTION
## Changelog Description
Corrects the `stagingDir` path in the product resources extraction plugin to reference the parent directory containing the rendered file rather than the file path itself. This fixes representation staging when publishing editorial packages, ensuring the staging directory points to the correct folder location for proper file access during downstream publishing operations.

## Additional info
The bug was in `extract_product_resources.py` where `stagingDir` was incorrectly set to the full file path (`str(rendered)`) instead of its parent directory (`str(rendered.parent)`). Since AYON's representation system expects `stagingDir` to be a directory path and `files` to be the filename, this mismatch caused incorrect path resolution during integration.

## Testing notes:
1. Create a product with resources in Resolve
2. Publish an editorial package containing rendered files
3. Verify the representation's `stagingDir` points to the directory, not the file
4. Confirm downstream integrators can correctly locate and process the published files
