### PR TITLE
Allow a profile to create multiple render passes

### DIFF
--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 from pathlib import Path
 from pprint import pformat
 
@@ -48,30 +49,37 @@ class ExtractProductResources(
 
     def process(self, instance):
         instance.data.setdefault("representations", [])
+        integrate_clip_source, all_output_settings = self.get_settings(instance)
 
-        settings = self.get_settings(instance)
-        preset_path = Path(self.resolve_preset_path(settings["preset_path"]))
-        product_base_type = instance.data["productBaseType"]
+        # todo: find the source of this, i think it's some otio extractor
+        #       maybe skip adding the repre there? but settings would be in a different extractor... doesn't make sense
+        if not integrate_clip_source:
+            instance.data["representations"] = []   # disables clip source integration
 
-        # set rendering logger to inherit from publisher's logger
-        rendering.log = self.log
+        for settings in all_output_settings:
+            preset_path = Path(self.resolve_preset_path(settings["preset_path"]))
+            product_base_type = instance.data["productBaseType"]
 
-        if product_base_type == "editorial_pkg":
-            self._process_editorial_pkg(instance, settings, preset_path)
-        elif product_base_type == "plate":
-            self._process_plate(instance, settings, preset_path)
-        else:
-            self.log.warning(
-                "ExtractProductResources: unhandled product base type '%s', skipping.", product_base_type
-            )
+            # set rendering logger to inherit from publisher's logger
+            rendering.log = self.log
 
-    def get_settings(self, instance):
+            if product_base_type == "editorial_pkg":
+                self._process_editorial_pkg(instance, settings, preset_path)
+            elif product_base_type == "plate":
+                self._process_plate(instance, settings, preset_path)
+            else:
+                self.log.warning(
+                    "ExtractProductResources: unhandled product base type '%s', skipping.", product_base_type
+                )
+                return
+
+    def get_settings(self, instance) -> list[dict[str, Any]]:
         """Return normalised render settings for *instance*.
 
         Looks up ``resolve → publish → ExtractProductResources → profiles``,
         then profile-matches on task type / task name / product_base_type.
 
-        Returns a flat dict with keys:
+        Returns a list of flat dicts with keys:
             ``file_format``, ``codec``, ``preset_path``,
             and for *editorial_pkg* only: ``export_otio``, ``otio_rootless``.
         """
@@ -101,26 +109,31 @@ class ExtractProductResources(
             return self.get_default_settings(product_base_type)
 
         self.log.debug(f"Matched preset: {profile.get('name')}")
-        return self._normalize_preset(profile, product_base_type)
 
-    def _normalize_preset(self, preset, product_base_type):
+        result = []
+        for preset in profile.get(product_base_type, []):
+            normalized = self._normalize_preset(preset)
+            result.append(normalized)
+
+        return (profile["integrate_clip_source"], result)
+
+    def _normalize_preset(self, preset):
         """Flatten the nested preset structure into a render-ready dict."""
-        sub = preset.get(product_base_type, {})
-        preset_type = sub.get("preset_type")
-        fmt = sub.get(preset_type, {})
+        preset_type = preset["settings"].get("preset_type")
+        fmt = preset["settings"].get(preset_type, {})
 
         normalized = {
-            "name":        preset["name"],
+            "name":        preset["shared"]["repre_name"],
             "file_format": fmt.get("format"),
             "codec":       fmt.get("codec"),
             "preset_path": fmt.get("preset_path"),
-            "with_handles": sub.get("with_handles"),
-            "tags":        preset["tags"],
-            "custom_tags": preset["custom_tags"],
+            "with_handles": preset["settings"].get("with_handles"),
+            "tags":        preset["shared"]["tags"],
+            "custom_tags": preset["shared"]["custom_tags"],
+            "export_otio": preset["settings"].get("export_otio", None),
+            "otio_rootless": preset["settings"].get("otio_rootless", None),
         }
-        if product_base_type == "editorial_pkg":
-            normalized["export_otio"] = sub.get("export_otio")
-            normalized["otio_rootless"] = sub.get("otio_rootless")
+        self.log.debug(f"{normalized = }")
         return normalized
 
     def get_default_settings(self, product_base_type="editorial_pkg"):
@@ -302,17 +315,16 @@ class ExtractProductResources(
 
         frame_start = instance.data["frameStart"]
 
-        with_handles = settings.get("with_handles", False)
-
         folder_slug = instance.data["folderPath"].lstrip("/").replace("/", "_")
         clip_name = timeline_item.GetName()
         staging_dir = (
-            Path(self.staging_dir(instance)) / f"{folder_slug}_{clip_name}"
+            Path(self.staging_dir(instance)) / f"{folder_slug}_{clip_name}_{settings['name']}"
         )
         staging_dir.mkdir(parents=True, exist_ok=True)
         self.log.info("Staging directory: %s", staging_dir)
 
         preset_data = {}
+        with_handles = settings.get("with_handles", False)
         if with_handles:
             preset_data.update({
                 "NumFramesOfHandles": max(available_head, available_tail)

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -84,11 +84,6 @@ class ExtractProductResources(
             and for *editorial_pkg* only: ``export_otio``, ``otio_rootless``.
         """
         entity = get_current_task_entity()
-        if not entity:
-            self.log.warning("No current task entity — using default settings.")
-            product_base_type = instance.data["productBaseType"]
-            return self.get_default_settings(product_base_type)
-
         task_type = entity.get("taskType")
         task_name = entity.get("taskName")
         product_base_type = instance.data["productBaseType"]

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -98,10 +98,12 @@ class ExtractProductResources(
         )
 
         if not profile:
-            self.log.debug(
-                "No preset matched for family='%s', task_type='%s', task_name='%s'. Using defaults.", product_base_type, task_type, task_name
+            raise RuntimeError(
+                (
+                    f"No matching preset found for family='{product_base_type}'. "
+                    "Please visit your server settings and add a matching preset for this family."
+                )
             )
-            return self.get_default_settings(product_base_type)
 
         self.log.debug(f"Matched preset: {profile.get('name')}")
 

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -116,8 +116,8 @@ class ExtractProductResources(
 
     def _normalize_preset(self, preset):
         """Flatten the nested preset structure into a render-ready dict."""
-        preset_type = preset["settings"].get("preset_type")
-        fmt = preset["settings"].get(preset_type, {})
+        preset_type = preset["settings"]["preset_type"]
+        fmt = preset["settings"][preset_type]
 
         normalized = {
             "name":        preset["shared"]["repre_name"],

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -127,8 +127,8 @@ class ExtractProductResources(
             "with_handles": preset["settings"].get("with_handles"),
             "tags":        preset["shared"]["tags"],
             "custom_tags": preset["shared"]["custom_tags"],
-            "export_otio": preset["settings"].get("export_otio", None),
-            "otio_rootless": preset["settings"].get("otio_rootless", None),
+            "export_otio": preset["settings"].get("export_otio"),
+            "otio_rootless": preset["settings"].get("otio_rootless"),
         }
         self.log.debug(f"{normalized = }")
         return normalized

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -119,19 +119,19 @@ class ExtractProductResources(
 
     def _normalize_preset(self, preset):
         """Flatten the nested preset structure into a render-ready dict."""
-        preset_type = preset["settings"]["preset_type"]
-        fmt = preset["settings"][preset_type]
+        preset_type = preset["output_defs"]["preset_type"]
+        fmt = preset["output_defs"][preset_type]
 
         normalized = {
             "name":        preset["shared"]["repre_name"],
             "file_format": fmt.get("format"),
             "codec":       fmt.get("codec"),
             "preset_path": fmt.get("preset_path"),
-            "with_handles": preset["settings"].get("with_handles"),
+            "with_handles": preset["output_defs"].get("with_handles"),
             "tags":        preset["shared"]["tags"],
             "custom_tags": preset["shared"]["custom_tags"],
-            "export_otio": preset["settings"].get("export_otio"),
-            "otio_rootless": preset["settings"].get("otio_rootless"),
+            "export_otio": preset["output_defs"].get("export_otio"),
+            "otio_rootless": preset["output_defs"].get("otio_rootless"),
         }
         self.log.debug(f"{normalized = }")
         return normalized

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -132,6 +132,7 @@ class ExtractProductResources(
             "custom_tags": preset["shared"]["custom_tags"],
             "export_otio": preset["output_defs"].get("export_otio"),
             "otio_rootless": preset["output_defs"].get("otio_rootless"),
+            "colorspace": preset["shared"].get("colorspace"),
         }
         self.log.debug(f"{normalized = }")
         return normalized

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -133,26 +133,6 @@ class ExtractProductResources(
         self.log.debug(f"{normalized = }")
         return normalized
 
-    def get_default_settings(self, product_base_type="editorial_pkg"):
-        """Return hard-coded defaults when no matching preset is found."""
-        if product_base_type == "plate":
-            return {
-                "file_format": "EXR",
-                "codec":       "RGB half (DWAA)",
-                "preset_path": (
-                    "{ayon_render_presets}/clip/EXR_RGB_half_(DWAA).xml"
-                ),
-            }
-        return {
-            "file_format":   "QuickTime",
-            "codec":         "H.264",
-            "preset_path":   (
-                "{ayon_render_presets}/timeline/QuickTime_H264.xml"
-            ),
-            "export_otio": True,
-            "otio_rootless": True,
-        }
-
     def resolve_preset_path(self, preset_path):
         """Resolve the path to a render preset file.
 

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -56,10 +56,8 @@ class ExtractProductResources(
         instance.data.setdefault("representations", [])
         integrate_clip_source, all_output_settings = self.get_settings(instance)
 
-        # todo: find the source of this, i think it's some otio extractor
-        #       maybe skip adding the repre there? but settings would be in a different extractor... doesn't make sense
         if not integrate_clip_source:
-            instance.data["representations"] = []   # disables clip source integration
+            instance.data["representations"] = []
 
         for settings in all_output_settings:
             preset_path = Path(self.resolve_preset_path(settings["preset_path"]))

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -301,8 +301,7 @@ class ExtractProductResources(
         self.log.info("Staging directory: %s", staging_dir)
 
         preset_data = {}
-        with_handles = settings.get("with_handles", False)
-        if with_handles:
+        if settings["with_handles"]:
             preset_data.update({
                 "NumFramesOfHandles": max(available_head, available_tail)
             })

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -5,7 +5,12 @@ from pprint import pformat
 
 import pyblish.api
 from ayon_core.lib import StringTemplate, filter_profiles
-from ayon_core.pipeline import Anatomy, get_current_project_name, publish
+from ayon_core.pipeline import (
+    Anatomy,
+    get_current_project_name,
+    publish,
+    PublishError,
+)
 from ayon_core.pipeline.context_tools import get_current_task_entity
 from ayon_resolve.api import rendering
 from ayon_resolve.api.lib import (
@@ -98,7 +103,7 @@ class ExtractProductResources(
         )
 
         if not profile:
-            raise RuntimeError(
+            raise PublishError(
                 f"No matching preset found for family='{product_base_type}'. "
                 "Please visit your server settings and add a matching preset for this family."
             )

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -99,10 +99,8 @@ class ExtractProductResources(
 
         if not profile:
             raise RuntimeError(
-                (
-                    f"No matching preset found for family='{product_base_type}'. "
-                    "Please visit your server settings and add a matching preset for this family."
-                )
+                f"No matching preset found for family='{product_base_type}'. "
+                "Please visit your server settings and add a matching preset for this family."
             )
 
         self.log.debug(f"Matched preset: {profile.get('name')}")

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -113,6 +113,11 @@ class ExtractProductResources(
             normalized = self._normalize_preset(preset)
             result.append(normalized)
 
+        if not result:
+            raise PublishError(
+                f"No matching output definitions found for preset='{profile}'. "
+            )
+
         return (profile["integrate_clip_source"], result)
 
     def _normalize_preset(self, preset):
@@ -259,6 +264,11 @@ class ExtractProductResources(
                 "stagingDir": str(rendered.parent),
             })
 
+        # ensure valid name
+        if not representation["name"]:
+            self.log.warning("Could not find representation name from settings, using extension")
+            representation["name"] = representation["ext"]
+
         # attach colorspace to the representation
         if settings.get("colorspace"):
             colorspace = settings["colorspace"]
@@ -362,6 +372,11 @@ class ExtractProductResources(
                 "ext":        rendered.suffix.lstrip(".").lower(),
                 "files":      rendered.name,
             })
+
+        # ensure valid name
+        if not representation["name"]:
+            self.log.warning("Could not find representation name from settings, using extension")
+            representation["name"] = representation["ext"]
 
         # attach colorspace to the representation
         if settings.get("colorspace"):

--- a/client/ayon_resolve/plugins/publish/extract_product_resources.py
+++ b/client/ayon_resolve/plugins/publish/extract_product_resources.py
@@ -264,6 +264,11 @@ class ExtractProductResources(
                 "stagingDir": str(rendered.parent),
             })
 
+        # ensure valid name
+        if not representation["name"]:
+            self.log.warning("Could not find representation name from settings, using extension")
+            representation["name"] = representation["ext"]
+
         # attach colorspace to the representation
         if settings.get("colorspace"):
             colorspace = settings["colorspace"]
@@ -367,6 +372,11 @@ class ExtractProductResources(
                 "ext":        rendered.suffix.lstrip(".").lower(),
                 "files":      rendered.name,
             })
+
+        # ensure valid name
+        if not representation["name"]:
+            self.log.warning("Could not find representation name from settings, using extension")
+            representation["name"] = representation["ext"]
 
         # attach colorspace to the representation
         if settings.get("colorspace"):

--- a/server/conversion.py
+++ b/server/conversion.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from semver import VersionInfo
+
 
 def _convert_ayon_menu_0_4_1(overrides):
     if "launch_openpype_menu_on_start" not in overrides:
@@ -8,9 +10,52 @@ def _convert_ayon_menu_0_4_1(overrides):
     overrides["launch_ayon_menu_on_start"] = overrides.pop("launch_openpype_menu_on_start")
 
 
+def _convert_ExtractProductResources_0_6_3(
+    version: VersionInfo,
+    overrides: dict[str, Any],
+):
+    if (version.major, version.minor, version.patch) > (0, 6, 3):
+        return
+
+    extract_product_profiles = (
+        overrides
+        .get("publish", {})
+        .get("ExtractProductResources", {})
+        .get("profiles")
+    )
+    if not extract_product_profiles:
+        return
+
+    for profile in extract_product_profiles:
+        product_base_type = profile.get("product_base_type")
+
+        shared = {}
+        for key in ("tags", "custom_tags", "colorspace"):
+            override_value = profile.pop(key, None)
+            if override_value is not None:
+                shared[key] = override_value
+
+        for base_type in ("editorial_pkg", "plate"):
+            old_output_defs = profile.get(base_type)
+            if not isinstance(old_output_defs, dict):
+                continue
+
+            profile_entry = {}
+            if old_output_defs:
+                profile_entry["output_defs"] = old_output_defs
+
+            if base_type == product_base_type and shared:
+                profile_entry["shared"] = shared
+
+            profile[base_type] = [profile_entry] if profile_entry else []
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
+    version = VersionInfo.parse(source_version)
+
     _convert_ayon_menu_0_4_1(overrides)
+    _convert_ExtractProductResources_0_6_3(version, overrides)
     return overrides

--- a/server/settings.py
+++ b/server/settings.py
@@ -95,6 +95,7 @@ def representation_tags_enum():
         {"value": "review", "label": "Extract review processing"},
         {"value": "delete", "label": "Delete - as intermediate"},
         {"value": "passing", "label": "Skip Extract Review"},
+        {"value": "webreview", "label": "Upload as reviewable"},
     ]
 
 
@@ -203,6 +204,7 @@ class BuiltinPlateFormatModel(BaseSettingsModel):
         title="Preset",
         enum_resolver=_builtin_plate_presets,
     )
+    # todo: this needs to be a selection for the user
     codec: str = SettingsField(
         "RGB half (DWAA)",
         title="Codec",
@@ -278,11 +280,63 @@ class PlateFormatModel(BaseSettingsModel):
         title="With Handles",
     )
 
+
+class ProductTypeSharedModel(BaseSettingsModel):
+    _layout = "expanded"
+    repre_name: str = SettingsField(
+        "",
+        title="Name",
+        section="Representation attributes",
+    )
+    tags: list[str] = SettingsField(
+        default_factory=list,
+        title="Tags",
+        enum_resolver=representation_tags_enum,
+        description="Currently only partly supporting reviewable workflow.",
+    )
+    custom_tags: list[str] = SettingsField(
+        default_factory=list,
+        title="Custom Tags",
+        description=(
+            "Ideal for additional filtering under Extract Review plugin.")
+    )
+    colorspace: str = SettingsField(
+        "",
+        title="Colorspace",
+        description="The colorspace to be added to colorspace metadata."
+    )
+
+
+class EditorialPKGModel(BaseSettingsModel):
+    _layout = "expanded"
+    # todo: better name for settings and shared
+    settings: TimelineIntermediateFormatModel = SettingsField(
+        default_factory=TimelineIntermediateFormatModel,
+        title="Timeline Attributes",
+    )
+    shared: ProductTypeSharedModel = SettingsField(
+        default_factory=ProductTypeSharedModel,
+        title="Shared Attributes"
+    )
+
+
+class PlateModel(BaseSettingsModel):
+    _layout = "expanded"
+    settings: PlateFormatModel = SettingsField(
+        default_factory=PlateFormatModel,
+        title="Plate Attributes",
+    )
+    shared: ProductTypeSharedModel = SettingsField(
+        default_factory=ProductTypeSharedModel,
+        title="Shared Attributes"
+    )
+
+
 class ProductResourcesPresetModel(BaseSettingsModel):
     """Product Resources Preset."""
     name: str = SettingsField(
         "",
-        title="Name"
+        title="Preset Name"
     )
     task_types: list[str] = SettingsField(
         default_factory=list,
@@ -300,31 +354,22 @@ class ProductResourcesPresetModel(BaseSettingsModel):
         enum_resolver=_product_base_types_enum,
         conditional_enum=True
     )
-    editorial_pkg: TimelineIntermediateFormatModel = SettingsField(
-        default_factory=TimelineIntermediateFormatModel,
-        title="Timeline Attributes",
-    )
-    plate: PlateFormatModel = SettingsField(
-        default_factory=PlateFormatModel,
-        title="Plate Attributes",
-    )
-    tags: list[str] = SettingsField(
-        default_factory=list,
-        title="Tags",
-        enum_resolver=representation_tags_enum,
-        description="Currently only partly supporting reviewable workflow.",
-        section="Representation attributes",
-    )
-    custom_tags: list[str] = SettingsField(
-        default_factory=list,
-        title="Custom Tags",
+    integrate_clip_source: bool = SettingsField(
+        False,
+        title="Integrate Clip Source",
         description=(
-            "Ideal for additional filtering under Extract Review plugin.")
+            "When enabled integrate the timeline item's media pool item as additional representation."
+        )
     )
-    colorspace: str = SettingsField(
-        "",
-        title="Colorspace",
-        description="The colorspace to be added to colorspace metadata."
+
+    # conditional properties based on product_base_type
+    editorial_pkg: list[EditorialPKGModel] = SettingsField(
+        default_factory=list,
+        title="Editorial PKG"
+    )
+    plate: list[PlateModel] = SettingsField(
+        default_factory=list,
+        title="Plate"
     )
 
 
@@ -536,33 +581,34 @@ DEFAULT_VALUES = {
             ]
         }
     },
-    "publish": {
-        "ExtractProductResources": {
-            "profiles": [
-                {
-                    "name": "timeline_reviewable",
-                    "task_types": [],
-                    "task_names": [],
-                    "product_base_type": "editorial_pkg",
-                    "editorial_pkg": {
-                        "preset_type": "builtin_preset",
-                    },
-                    "tags": ["review", "delete"],
-                    "custom_tags": []
-                },
-                {
-                    "name": "plate_exr_dwaa",
-                    "task_types": [],
-                    "task_names": [],
-                    "product_base_type": "plate",
-                    "plate": {
-                        "preset_type": "builtin_preset",
-                        "with_handles": True,
-                    },
-                    "tags": ["passing"],
-                    "custom_tags": []
-                }
-            ]
-        }
-    }
+    # todo: paste sane defaults, commented out rn to not make frontend suffer too much
+    # "publish": {
+    #     "ExtractProductResources": {
+    #         "profiles": [
+    #             {
+    #                 "name": "timeline_reviewable",
+    #                 "task_types": [],
+    #                 "task_names": [],
+    #                 "product_base_type": "editorial_pkg",
+    #                 "editorial_pkg": {
+    #                     "preset_type": "builtin_preset",
+    #                 },
+    #                 "tags": ["review", "delete"],
+    #                 "custom_tags": []
+    #             },
+    #             {
+    #                 "name": "plate_exr_dwaa",
+    #                 "task_types": [],
+    #                 "task_names": [],
+    #                 "product_base_type": "plate",
+    #                 "plate": {
+    #                     "preset_type": "builtin_preset",
+    #                     "with_handles": True,
+    #                 },
+    #                 "tags": ["passing"],
+    #                 "custom_tags": []
+    #             }
+    #         ]
+    #     }
+    # }
 }

--- a/server/settings.py
+++ b/server/settings.py
@@ -308,9 +308,7 @@ class ProductTypeSharedModel(BaseSettingsModel):
 
 
 class EditorialPKGModel(BaseSettingsModel):
-    _layout = "expanded"
-    # todo: better name for settings and shared
-    settings: TimelineIntermediateFormatModel = SettingsField(
+    output_defs: TimelineIntermediateFormatModel = SettingsField(
         default_factory=TimelineIntermediateFormatModel,
     )
     shared: ProductTypeSharedModel = SettingsField(
@@ -319,8 +317,7 @@ class EditorialPKGModel(BaseSettingsModel):
 
 
 class PlateModel(BaseSettingsModel):
-    _layout = "expanded"
-    settings: PlateFormatModel = SettingsField(
+    output_defs: PlateFormatModel = SettingsField(
         default_factory=PlateFormatModel,
         title="Plate Attributes",
     )
@@ -368,11 +365,13 @@ class ProductResourcesPresetModel(BaseSettingsModel):
     # conditional properties based on product_base_type
     editorial_pkg: list[EditorialPKGModel] = SettingsField(
         default_factory=list,
-        title="Editorial PKG"
+        title="Output Definitions",
+        description="Configures Resolve render settings for each representation to be exported."
     )
     plate: list[PlateModel] = SettingsField(
         default_factory=list,
-        title="Plate"
+        title="Output Definitions",
+        description="Configures Resolve render settings for each representation to be exported."
     )
 
     @validator("editorial_pkg", "plate")

--- a/server/settings.py
+++ b/server/settings.py
@@ -372,6 +372,18 @@ class ProductResourcesPresetModel(BaseSettingsModel):
         title="Plate"
     )
 
+    @validator("editorial_pkg", "plate")
+    def validate_unique_outputs(cls, values):
+        # ensure_unique_names unfortunately is hardcoded to use `name` as field key
+        names = []
+        for val in values:
+            if val.shared.repre_name not in names:
+                names.append(val.shared.repre_name)
+            else:
+                raise ValueError(f"Duplicate representation name: {val.shared.repre_name}")
+
+        return values
+
 
 class ExtractProductResourcesModel(BaseSettingsModel):
     """Extract Product Resources.

--- a/server/settings.py
+++ b/server/settings.py
@@ -73,6 +73,10 @@ def _builtin_plate_presets():
             "label": "EXR RGB float (ZIP)",
             "value": "{ayon_render_presets}/clip/EXR_RGB_float_(ZIP).xml"
         },
+        {
+            "label": "QuickTime H264",
+            "value": "{ayon_render_presets}/timeline/QuickTime_H264.xml"
+        },
     ]
 
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -377,10 +377,9 @@ class ProductResourcesPresetModel(BaseSettingsModel):
         # ensure_unique_names unfortunately is hardcoded to use `name` as field key
         names = []
         for val in values:
-            if val.shared.repre_name not in names:
-                names.append(val.shared.repre_name)
-            else:
+            if val.shared.repre_name in names:
                 raise ValueError(f"Duplicate representation name: {val.shared.repre_name}")
+            names.append(val.shared.repre_name)
 
         return values
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -219,7 +219,7 @@ class CustomPresetModel(BaseSettingsModel):
     )
     preset_path: str = SettingsField(
         "",
-        title="Preset path",
+        title="Preset Path",
         placeholder="shared storage path with `{root[work]}` token",
     )
     codec: str = SettingsField(
@@ -247,7 +247,7 @@ class TimelineIntermediateFormatModel(BaseSettingsModel):
         title="Preset type",
         enum_resolver=_preset_types_enum,
         conditional_enum=True,
-        section="Preset options",
+        section="Preset Options",
     )
     builtin_preset: BuiltinTimelineFormatModel = SettingsField(
         default_factory=BuiltinTimelineFormatModel,
@@ -262,10 +262,10 @@ class PlateFormatModel(BaseSettingsModel):
     _layout = "expanded"
     preset_type: str = SettingsField(
         "builtin_preset",
-        title="Preset type",
+        title="Preset Type",
         enum_resolver=_preset_types_enum,
         conditional_enum=True,
-        section="Preset options",
+        section="Preset Options",
     )
     builtin_preset: BuiltinPlateFormatModel = SettingsField(
         default_factory=BuiltinPlateFormatModel,
@@ -286,7 +286,7 @@ class ProductTypeSharedModel(BaseSettingsModel):
     repre_name: str = SettingsField(
         "",
         title="Name",
-        section="Representation attributes",
+        section="Representation Attributes",
     )
     tags: list[str] = SettingsField(
         default_factory=list,
@@ -340,17 +340,17 @@ class ProductResourcesPresetModel(BaseSettingsModel):
     )
     task_types: list[str] = SettingsField(
         default_factory=list,
-        title="Task types",
+        title="Task Types",
         enum_resolver=task_types_enum,
         section="Profile filtering",
     )
     task_names: list[str] = SettingsField(
         default_factory=list,
-        title="Task names"
+        title="Task Names"
     )
     product_base_type: str = SettingsField(
         "editorial_pkg",
-        title="Product base type",
+        title="Product Base Type",
         enum_resolver=_product_base_types_enum,
         conditional_enum=True
     )

--- a/server/settings.py
+++ b/server/settings.py
@@ -312,11 +312,9 @@ class EditorialPKGModel(BaseSettingsModel):
     # todo: better name for settings and shared
     settings: TimelineIntermediateFormatModel = SettingsField(
         default_factory=TimelineIntermediateFormatModel,
-        title="Timeline Attributes",
     )
     shared: ProductTypeSharedModel = SettingsField(
         default_factory=ProductTypeSharedModel,
-        title="Shared Attributes"
     )
 
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -581,34 +581,73 @@ DEFAULT_VALUES = {
             ]
         }
     },
-    # todo: paste sane defaults, commented out rn to not make frontend suffer too much
-    # "publish": {
-    #     "ExtractProductResources": {
-    #         "profiles": [
-    #             {
-    #                 "name": "timeline_reviewable",
-    #                 "task_types": [],
-    #                 "task_names": [],
-    #                 "product_base_type": "editorial_pkg",
-    #                 "editorial_pkg": {
-    #                     "preset_type": "builtin_preset",
-    #                 },
-    #                 "tags": ["review", "delete"],
-    #                 "custom_tags": []
-    #             },
-    #             {
-    #                 "name": "plate_exr_dwaa",
-    #                 "task_types": [],
-    #                 "task_names": [],
-    #                 "product_base_type": "plate",
-    #                 "plate": {
-    #                     "preset_type": "builtin_preset",
-    #                     "with_handles": True,
-    #                 },
-    #                 "tags": ["passing"],
-    #                 "custom_tags": []
-    #             }
-    #         ]
-    #     }
-    # }
+    "publish": {
+        "ExtractProductResources": {
+            "profiles": [
+                {
+                    "name": "Plate Clip Preset",
+                    "task_types": [],
+                    "task_names": [],
+                    "product_base_type": "plate",
+                    "editorial_pkg": [],
+                    "plate": [
+                        {
+                            "settings": {
+                                "preset_type": "builtin_preset",
+                                "builtin_preset": {
+                                    "format": "EXR",
+                                    "preset_path": "{ayon_render_presets}/clip/EXR_RGB_half_(DWAA).xml",
+                                    "codec": "RGB half (DWAA)",
+                                },
+                                "custom_preset": {
+                                    "format": "QuickTime",
+                                    "preset_path": "",
+                                    "codec": "H.264",
+                                },
+                                "with_handles": True,
+                            },
+                            "shared": {
+                                "repre_name": "exr",
+                                "tags": [],
+                                "custom_tags": [],
+                                "colorspace": "",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "name": "Editorial Package Preset",
+                    "task_types": [],
+                    "task_names": [],
+                    "product_base_type": "editorial_pkg",
+                    "editorial_pkg": [
+                        {
+                            "settings": {
+                                "export_otio": True,
+                                "otio_rootless": True,
+                                "preset_type": "builtin_preset",
+                                "builtin_preset": {
+                                    "format": "QuickTime",
+                                    "preset_path": "{ayon_render_presets}/timeline/QuickTime_H264.xml",
+                                    "codec": "H.264",
+                                },
+                                "custom_preset": {
+                                    "format": "QuickTime",
+                                    "preset_path": "",
+                                    "codec": "H.264",
+                                },
+                            },
+                            "shared": {
+                                "repre_name": "mov",
+                                "tags": ["passing"],
+                                "custom_tags": [],
+                                "colorspace": "",
+                            },
+                        }
+                    ],
+                    "plate": [],
+                },
+            ]
+        }
+    },
 }

--- a/server/settings.py
+++ b/server/settings.py
@@ -334,7 +334,12 @@ class ProductResourcesPresetModel(BaseSettingsModel):
     """Product Resources Preset."""
     name: str = SettingsField(
         "",
-        title="Preset Name"
+        title="Profile Name",
+        description=(
+            "The name of the profile. If left empty, "
+            "a default name based on selected product base type will be assigned on save. "
+            "No further logic is connected to this."
+        )
     )
     task_types: list[str] = SettingsField(
         default_factory=list,
@@ -393,6 +398,18 @@ class ExtractProductResourcesModel(BaseSettingsModel):
             "resource extraction."
         )
     )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        plate_profiles = [profile for profile in self.profiles if profile.product_base_type == "plate"]
+        editorial_pkg_profiles = [profile for profile in self.profiles if profile.product_base_type == "editorial_pkg"]
+        for idx, profile in enumerate(plate_profiles):
+            if not profile.name:
+                profile.name = f"Plate Profile #{idx + 1}"
+        for idx, profile in enumerate(editorial_pkg_profiles):
+            if not profile.name:
+                profile.name = f"Editorial PKG Profile #{idx + 1}"
 
     @validator("profiles")
     def validate_unique_outputs(cls, value):
@@ -594,7 +611,7 @@ DEFAULT_VALUES = {
         "ExtractProductResources": {
             "profiles": [
                 {
-                    "name": "Plate Clip Preset",
+                    "name": "Plate Profile #1",
                     "task_types": [],
                     "task_names": [],
                     "product_base_type": "plate",
@@ -625,7 +642,7 @@ DEFAULT_VALUES = {
                     ],
                 },
                 {
-                    "name": "Editorial Package Preset",
+                    "name": "Editorial PKG Profile #1",
                     "task_types": [],
                     "task_names": [],
                     "product_base_type": "editorial_pkg",

--- a/server/settings.py
+++ b/server/settings.py
@@ -234,7 +234,7 @@ class TimelineIntermediateFormatModel(BaseSettingsModel):
         title="Export OTIO",
         description="When enabled AYON will export OTIO file"
         " along with intermediate file.",
-        section="Timeline options",
+        section="Timeline Options",
     )
     otio_rootless: bool = SettingsField(
         True,
@@ -244,7 +244,7 @@ class TimelineIntermediateFormatModel(BaseSettingsModel):
     )
     preset_type: str = SettingsField(
         "builtin_preset",
-        title="Preset type",
+        title="Preset Type",
         enum_resolver=_preset_types_enum,
         conditional_enum=True,
         section="Preset Options",
@@ -340,7 +340,7 @@ class ProductResourcesPresetModel(BaseSettingsModel):
         default_factory=list,
         title="Task Types",
         enum_resolver=task_types_enum,
-        section="Profile filtering",
+        section="Profile Filtering",
     )
     task_names: list[str] = SettingsField(
         default_factory=list,

--- a/server/settings.py
+++ b/server/settings.py
@@ -621,7 +621,7 @@ DEFAULT_VALUES = {
                     "editorial_pkg": [],
                     "plate": [
                         {
-                            "settings": {
+                            "output_defs": {
                                 "preset_type": "builtin_preset",
                                 "builtin_preset": {
                                     "format": "EXR",
@@ -651,7 +651,7 @@ DEFAULT_VALUES = {
                     "product_base_type": "editorial_pkg",
                     "editorial_pkg": [
                         {
-                            "settings": {
+                            "output_defs": {
                                 "export_otio": True,
                                 "otio_rootless": True,
                                 "preset_type": "builtin_preset",


### PR DESCRIPTION
## Changelog Description
This draft shall make it possible to render more than 1 representation per instance.
Also it aims at making source clip integration optional.

General goal of this is to make use of resolve rendering engine as much as possible to not needing to go through `extract_review` as this comes with performance penalties compared to resolve.

## Additional review information
- changes profile structure to allow multiple representations to be rendered
- adds `Upload as reviewable` tag (really just `webreview` under the hood)

I tested this for `plate` and `editorial_pkg` products on windows only.

## Testing notes:
- build & upload the addon
- configure more than 1 representation pass
- publish and check for your expected output
