### PR TITLE
Replace qargparse with attribute definitions

### DIFF
--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -2,8 +2,6 @@ import copy
 import re
 import uuid
 
-import qargparse
-
 from ayon_core.pipeline.constants import AVALON_INSTANCE_ID
 from ayon_core.pipeline import (
     LoaderPlugin,
@@ -11,6 +9,7 @@ from ayon_core.pipeline import (
     HiddenCreator,
     Anatomy
 )
+from ayon_core.lib import BoolDef, EnumDef
 
 from . import lib, constants
 
@@ -239,23 +238,23 @@ class TimelineItemLoader(LoaderPlugin):
     """
 
     options = [
-        qargparse.Boolean(
+        BoolDef(
             "handles",
             label="Include handles",
-            default=0,
+            default=False,
             help="Load with handles or without?"
         ),
-        qargparse.Choice(
+        EnumDef(
             "load_to",
             label="Where to load clips",
             items=[
                 "Current timeline",
                 "New timeline"
             ],
-            default=0,
+            default="Current timeline",
             help="Where do you want clips to be loaded?"
         ),
-        qargparse.Choice(
+        EnumDef(
             "load_how",
             label="How to load clips",
             items=[

--- a/client/ayon_resolve/api/plugin.py
+++ b/client/ayon_resolve/api/plugin.py
@@ -242,7 +242,7 @@ class TimelineItemLoader(LoaderPlugin):
             "handles",
             label="Include handles",
             default=False,
-            help="Load with handles or without?"
+            tooltip="Load with handles or without?"
         ),
         EnumDef(
             "load_to",
@@ -252,7 +252,7 @@ class TimelineItemLoader(LoaderPlugin):
                 "New timeline"
             ],
             default="Current timeline",
-            help="Where do you want clips to be loaded?"
+            tooltip="Where do you want clips to be loaded?"
         ),
         EnumDef(
             "load_how",
@@ -262,7 +262,7 @@ class TimelineItemLoader(LoaderPlugin):
                 "Sequentially in order"
             ],
             default="Original timing",
-            help="Would you like to place it at original timing?"
+            tooltip="Would you like to place it at original timing?"
         )
     ]
 


### PR DESCRIPTION
## Changelog Description

Replace qargparse with attribute definitions

## Additional review information

Clean up usage of `qargparse` and starting using AYON's attribute definitons.

## Testing notes:

1. Load options should still work
