### PR TITLE
Pre launch hooks: Handle workfile path in pre-launch hook

### DIFF
--- a/client/ayon_resolve/hooks/pre_resolve_last_workfile.py
+++ b/client/ayon_resolve/hooks/pre_resolve_last_workfile.py
@@ -13,23 +13,33 @@ class PreLaunchResolveLastWorkfile(PreLaunchHook):
     launch_types = {LaunchTypes.local}
 
     def execute(self):
-        if not self.data.get("start_last_workfile"):
-            self.log.info("It is set to not start last workfile on start.")
-            return
-
-        last_workfile = self.data.get("last_workfile_path")
-        if not last_workfile:
-            self.log.warning("Last workfile was not collected.")
-            return
-
-        if not os.path.exists(last_workfile):
-            self.log.info("Current context does not have any workfile yet.")
+        workfile_path = self.get_workfile_path()
+        if not workfile_path:
             return
 
         # Add path to launch environment for the startup script to pick up
         self.log.info(
             "Setting AYON_RESOLVE_OPEN_ON_LAUNCH to launch "
-            f"last workfile: {last_workfile}"
+            f"last workfile: {workfile_path}"
         )
         key = "AYON_RESOLVE_OPEN_ON_LAUNCH"
-        self.launch_context.env[key] = last_workfile
+        self.launch_context.env[key] = workfile_path
+
+    def get_workfile_path(self):
+        workfile_path = self.data.get("workfile_path")
+        if workfile_path:
+            return workfile_path
+
+        if not self.data.get("start_last_workfile"):
+            self.log.info("It is set to not start last workfile on start.")
+            return None
+
+        last_workfile = self.data.get("last_workfile_path")
+        if not last_workfile:
+            self.log.warning("Last workfile was not collected.")
+            return None
+
+        if not os.path.exists(last_workfile):
+            self.log.info("Current context does not have any workfile yet.")
+            return None
+        return last_workfile

--- a/client/ayon_resolve/hooks/pre_resolve_last_workfile.py
+++ b/client/ayon_resolve/hooks/pre_resolve_last_workfile.py
@@ -19,8 +19,8 @@ class PreLaunchResolveLastWorkfile(PreLaunchHook):
 
         # Add path to launch environment for the startup script to pick up
         self.log.info(
-            "Setting AYON_RESOLVE_OPEN_ON_LAUNCH to launch "
-            f"last workfile: {workfile_path}"
+            "Setting AYON_RESOLVE_OPEN_ON_LAUNCH to open "
+            f"workfile: {workfile_path}"
         )
         key = "AYON_RESOLVE_OPEN_ON_LAUNCH"
         self.launch_context.env[key] = workfile_path


### PR DESCRIPTION
## Changelog Description
Care about `workfile_path` set in launch hooks data.

## Additional review information
Resolve does not respect explicitly set workfile path under `"workfile_path"` on hook data which means it will try to launch the last one on open.

NOTE I did have the changes localy without a PR so I'm not sure if there was a reason why not to do this?

## Testing notes:
1. Explicitly selected workfile in launcher tool should open the selected workfile instead of last workfile.
