### PR TITLE
Chore: Use new editorial families

### DIFF
--- a/client/ayon_resolve/plugins/publish/collect_plates.py
+++ b/client/ayon_resolve/plugins/publish/collect_plates.py
@@ -51,6 +51,8 @@ class CollectPlate(pyblish.api.InstancePlugin):
         if review_switch is True:
             if reviewable_source == "clip_media":
                 instance.data["families"].append("review")
+                # Tell 'CollectOTIOReviewTrack' to use the current clip
+                instance.data["otioReviewClips"] = [otio_clip]
                 instance.data.pop("reviewTrack", None)
             else:
                 instance.data["reviewTrack"] = reviewable_source

--- a/client/ayon_resolve/plugins/publish/collect_plates.py
+++ b/client/ayon_resolve/plugins/publish/collect_plates.py
@@ -18,7 +18,15 @@ class CollectPlate(pyblish.api.InstancePlugin):
         Args:
             instance (pyblish.Instance): The shot instance to update.
         """
-        instance.data["families"].append("clip")
+        instance.data["families"].extend([
+            "clip",
+            # Mark instance for 'CollectOTIORanges' in core
+            "otio.review.track",
+            # Mark instance for 'CollectOTIOReviewTrack' in core
+            "otio.clip.ranges",
+            # Mark instance for 'CollectOTIOProductResources' in core
+            "otio.clip.resources",
+        ])
         track_item = instance.data["transientData"]["track_item"]
         instance.data["timelineItem"] = track_item
 

--- a/client/ayon_resolve/plugins/publish/collect_plates.py
+++ b/client/ayon_resolve/plugins/publish/collect_plates.py
@@ -20,9 +20,9 @@ class CollectPlate(pyblish.api.InstancePlugin):
         """
         instance.data["families"].extend([
             "clip",
-            # Mark instance for 'CollectOTIORanges' in core
-            "otio.review.track",
             # Mark instance for 'CollectOTIOReviewTrack' in core
+            "otio.review.track",
+            # Mark instance for 'CollectOTIORanges' in core
             "otio.clip.ranges",
             # Mark instance for 'CollectOTIOProductResources' in core
             "otio.clip.resources",

--- a/client/ayon_resolve/plugins/publish/collect_shots.py
+++ b/client/ayon_resolve/plugins/publish/collect_shots.py
@@ -54,6 +54,9 @@ class CollectShot(pyblish.api.InstancePlugin):
         Args:
             instance (pyblish.Instance): The shot instance to update.
         """
+        # Mark instance for 'CollectOTIORanges' in core
+        instance.data["families"].append("otio.clip.ranges")
+
         instance.data["integrate"] = False  # no representation for shot
         track_item = instance.data["transientData"]["track_item"]
 

--- a/client/ayon_resolve/plugins/publish/collect_workfile.py
+++ b/client/ayon_resolve/plugins/publish/collect_workfile.py
@@ -5,7 +5,7 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     """Collect additional metadata for workfile instance."""
 
     label = "Collect Workfile"
-    order = pyblish.api.CollectorOrder - 0.45
+    order = pyblish.api.CollectorOrder - 0.49
     hosts = ["resolve"]
     families = ["workfile"]
 

--- a/client/ayon_resolve/plugins/publish/collect_workfile.py
+++ b/client/ayon_resolve/plugins/publish/collect_workfile.py
@@ -1,0 +1,14 @@
+import pyblish.api
+
+
+class CollectWorkfile(pyblish.api.InstancePlugin):
+    """Collect additional metadata for workfile instance."""
+
+    label = "Collect Workfile"
+    order = pyblish.api.CollectorOrder - 0.45
+    hosts = ["resolve"]
+    families = ["workfile"]
+
+    def process(self, instance):
+        # Mark instance for 'ExtractOTIOFile' in core
+        instance.data["families"].append("otio.timeline.workfile")


### PR DESCRIPTION
## Changelog Description
Use new families defined in core to process editorial instances.

## Additional review information
[This PR](https://github.com/ynput/ayon-core/pull/1967) in ayon core is adding new families that are used to explicitly process instances instead of host based processing.

This PR is adding the families but should still work with old core. The same the core PR should work with hiero develop.

## Testing notes:
All possible combinations of ayon-core and ayon-hiero should produce exactly same output.
- resolve develop + core develop
- resolve PR + core PR
- resolve PR + core develop
- resolve develop + core PR
